### PR TITLE
feat: JWT caching for Yivi decryption and flexible signing attributes

### DIFF
--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -94,7 +94,8 @@ export async function resolveUSK(
   policy: { ts: number; con: { t: string; v?: string }[] },
   element?: string,
   session?: SessionCallback,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  enableCache?: boolean
 ): Promise<unknown> {
   const keyRequest = buildKeyRequest(recipientKey, policy);
 
@@ -111,7 +112,7 @@ export async function resolveUSK(
   }
 
   if (element) {
-    return retrieveUSKViaYivi(pkgUrl, element, keyRequest, policy.ts);
+    return retrieveUSKViaYivi(pkgUrl, element, keyRequest, policy.ts, enableCache, recipientKey);
   }
 
   throw new DecryptionError('Either element or session callback must be provided for decryption.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export type {
   DecryptFileResult,
   DecryptDataResult,
   UploadResult,
+  // Attribute types
+  AttributeCon,
   // Email
   BuildMimeOptions,
   CreateEnvelopeOptions,

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -83,6 +83,7 @@ export class Opened {
       opts.element,
       opts.session,
       this.config.headers,
+      opts.enableCache,
     );
 
     const { chunks, sender } = await unsealAndCollect(

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -29,7 +29,7 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail: string; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string }[]; includeSender?: boolean }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -6,11 +6,15 @@ import { getSigningKeysWithJwt } from '../api/pkg.js';
 export async function resolveSigningKeysFromSession(
   pkgUrl: string,
   callback: SessionCallback,
-  senderEmail: string,
+  senderEmail: string | undefined,
   headers?: HeadersInit
 ): Promise<SigningKeys> {
+  const emailAttr = senderEmail
+    ? { t: 'pbdf.sidn-pbdf.email.email', v: senderEmail }
+    : { t: 'pbdf.sidn-pbdf.email.email' };
+
   const jwt = await callback({
-    con: [{ t: 'pbdf.sidn-pbdf.email.email', v: senderEmail }],
+    con: [emailAttr],
     sort: 'Signing',
   });
 

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -5,7 +5,8 @@ import type { SigningKeys } from '../types.js';
 
 export interface YiviSignOptions {
   element: string;
-  senderEmail: string;
+  senderEmail?: string;
+  attributes?: { t: string; v?: string }[];
   includeSender?: boolean;
 }
 
@@ -27,7 +28,12 @@ export async function resolveSigningKeysFromYivi(
         ...extraHeaders,
       },
       body: JSON.stringify({
-        con: [{ t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }],
+        con: [
+          opts.senderEmail
+            ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
+            : { t: 'pbdf.sidn-pbdf.email.email' },
+          ...(opts.attributes ?? []),
+        ],
       }),
     },
     result: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,10 @@ export interface ApiKeySign {
 export interface YiviSign {
   type: 'yivi';
   element: string;
-  senderEmail: string;
+  senderEmail?: string;
+  /** Additional attributes to request in the Yivi session (e.g. name).
+   *  Email is always included automatically. */
+  attributes?: { t: string; v?: string }[];
   includeSender?: boolean;
 }
 
@@ -111,6 +114,8 @@ export interface DecryptInput {
   session?: SessionCallback;
   /** Hint: which recipient to decrypt for (required if multiple recipients) */
   recipient?: string;
+  /** Enable JWT caching to avoid re-scanning QR for repeated decryptions */
+  enableCache?: boolean;
 }
 
 // --- Results ---

--- a/src/yivi/decrypt-session.ts
+++ b/src/yivi/decrypt-session.ts
@@ -6,13 +6,98 @@ import { PostGuardError } from '../errors.js';
 // Re-export utilities from shared module
 export { sortPolicies, secondsTill4AM, buildKeyRequest } from '../util/policy.js';
 
+// --- JWT Cache ---
+
+interface CacheEntry {
+  jwt: string;
+  expiresAt: number; // Unix timestamp in seconds
+}
+
+const jwtCache = new Map<string, CacheEntry>();
+
+function getCacheKey(
+  recipientEmail: string,
+  con: { t: string; v?: string }[]
+): string {
+  return `${recipientEmail}:${JSON.stringify(con)}`;
+}
+
+/** Look up a cached JWT for this recipient+policy. Returns null if absent or expired. */
+function getCachedJwt(
+  recipientEmail: string,
+  con: { t: string; v?: string }[]
+): string | null {
+  const key = getCacheKey(recipientEmail, con);
+  const entry = jwtCache.get(key);
+  if (!entry) return null;
+
+  // Check expiry with 30s margin
+  if (Date.now() / 1000 >= entry.expiresAt - 30) {
+    jwtCache.delete(key);
+    return null;
+  }
+  return entry.jwt;
+}
+
+/** Store a JWT in the cache. Parses expiry from the JWT payload. */
+function cacheJwt(
+  recipientEmail: string,
+  con: { t: string; v?: string }[],
+  jwt: string
+): void {
+  try {
+    // Decode JWT payload (base64url → JSON)
+    const payload = jwt.split('.')[1];
+    const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+    const expiresAt = decoded.exp as number;
+    if (expiresAt) {
+      jwtCache.set(getCacheKey(recipientEmail, con), { jwt, expiresAt });
+    }
+  } catch {
+    // If we can't parse the JWT, don't cache it
+  }
+}
+
+// --- USK retrieval ---
+
+/** Retrieve a USK using a cached JWT (no Yivi session needed) */
+async function retrieveUSKWithJwt(
+  pkgUrl: string,
+  jwt: string,
+  timestamp: number
+): Promise<unknown> {
+  const response = await fetch(`${pkgUrl}/v2/irma/key/${timestamp.toString()}`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  const json = await response.json();
+  if (json.status !== 'DONE' || json.proofStatus !== 'VALID') {
+    throw new PostGuardError('Cached JWT session not valid');
+  }
+  return json.key;
+}
+
 /** Retrieve a User Secret Key (USK) via a Yivi session for decryption */
 export async function retrieveUSKViaYivi(
   pkgUrl: string,
   element: string,
   keyRequest: { con: { t: string; v?: string }[]; validity: number },
-  timestamp: number
+  timestamp: number,
+  enableCache?: boolean,
+  recipientEmail?: string
 ): Promise<unknown> {
+  // Check cache first
+  if (enableCache && recipientEmail) {
+    const cachedJwt = getCachedJwt(recipientEmail, keyRequest.con);
+    if (cachedJwt) {
+      try {
+        return await retrieveUSKWithJwt(pkgUrl, cachedJwt, timestamp);
+      } catch {
+        // Cache entry invalid, fall through to Yivi session
+        jwtCache.delete(getCacheKey(recipientEmail, keyRequest.con));
+      }
+    }
+  }
+
   const session = {
     url: pkgUrl,
     start: {
@@ -26,11 +111,15 @@ export async function retrieveUSKViaYivi(
       parseResponse: (r: Response) => {
         return r
           .text()
-          .then((jwt: string) =>
-            fetch(`${pkgUrl}/v2/irma/key/${timestamp.toString()}`, {
+          .then((jwt: string) => {
+            // Cache the JWT if caching is enabled
+            if (enableCache && recipientEmail) {
+              cacheJwt(recipientEmail, keyRequest.con, jwt);
+            }
+            return fetch(`${pkgUrl}/v2/irma/key/${timestamp.toString()}`, {
               headers: { Authorization: `Bearer ${jwt}` },
-            })
-          )
+            });
+          })
           .then((r: Response) => r.json())
           .then((json: any) => {
             if (json.status !== 'DONE' || json.proofStatus !== 'VALID') {


### PR DESCRIPTION
## Summary
- **JWT caching**: Add an in-memory cache for Yivi JWTs during decryption, so users don't need to re-scan the QR code for repeated decryptions. Enabled via the new `enableCache` option on `DecryptInput`.
- **Flexible signing attributes**: Make `senderEmail` optional in `YiviSign` and add an `attributes` array to request additional Yivi attributes (e.g. name) beyond the default email attribute.
- Export `AttributeCon` type from the package index.

## Test plan
- [ ] Verify decryption works with `enableCache: true` — second decrypt should skip QR scan
- [ ] Verify decryption still works without cache (default behavior unchanged)
- [ ] Verify signing works with `senderEmail` omitted (email attribute requested without value)
- [ ] Verify signing works with additional `attributes` passed