### PR TITLE
feat: Include sender in encryption policy via includeSender

### DIFF
--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -1,5 +1,5 @@
 import type { ISealOptions } from '@e4a/pg-wasm';
-import type { Recipient, SignMethod, SigningKeys, UploadResult } from '../types.js';
+import type { Recipient, SignMethod, SigningKeys, UploadResult, YiviSign } from '../types.js';
 import { fetchMPK } from '../api/pkg.js';
 import { createUploadStream } from '../api/cryptify.js';
 import { buildEncryptionPolicy } from '../recipients/builders.js';
@@ -44,6 +44,15 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   // Build encryption policy
   const ts = Math.round(Date.now() / 1000);
   const policy = buildEncryptionPolicy(recipients, ts);
+
+  // If the sign method requests including the sender, add a sender entry
+  // so the sender can also decrypt the sealed file.
+  if (sign.type === 'yivi' && (sign as YiviSign).includeSender && signingKeys.senderEmail) {
+    policy[signingKeys.senderEmail] = {
+      ts,
+      con: [{ t: 'pbdf.sidn-pbdf.email.email', v: signingKeys.senderEmail }],
+    };
+  }
 
   const sealOptions: ISealOptions = {
     policy,
@@ -111,6 +120,14 @@ export async function sealRaw(options: SealRawOptions): Promise<Uint8Array> {
   // Build encryption policy
   const ts = Math.round(Date.now() / 1000);
   const policy = buildEncryptionPolicy(recipients, ts);
+
+  // Include sender in policy if requested
+  if (sign.type === 'yivi' && (sign as YiviSign).includeSender && signingKeys.senderEmail) {
+    policy[signingKeys.senderEmail] = {
+      ts,
+      con: [{ t: 'pbdf.sidn-pbdf.email.email', v: signingKeys.senderEmail }],
+    };
+  }
 
   const sealOptions: ISealOptions = {
     policy,

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -10,6 +10,25 @@ export interface YiviSignOptions {
   includeSender?: boolean;
 }
 
+/** Extract the sender's email from an IRMA/Yivi session result JWT */
+function extractEmailFromJwt(jwt: string): string | undefined {
+  try {
+    const payload = JSON.parse(atob(jwt.split('.')[1]));
+    // IRMA session result JWT has disclosed attributes in various formats
+    const disclosed: any[][] = payload.disclosed ?? [];
+    for (const group of disclosed) {
+      for (const attr of group) {
+        if (attr.id?.endsWith('.email.email') || attr.id?.includes('email')) {
+          return attr.rawvalue ?? attr.value?.[''] ?? attr.value;
+        }
+      }
+    }
+  } catch {
+    // JWT decoding failed — not critical, caller handles missing email
+  }
+  return undefined;
+}
+
 /** Resolve signing keys via a Yivi session (peer-to-peer sending) */
 export async function resolveSigningKeysFromYivi(
   pkgUrl: string,
@@ -17,6 +36,7 @@ export async function resolveSigningKeysFromYivi(
   headers?: HeadersInit
 ): Promise<SigningKeys> {
   const extraHeaders = headers ? Object.fromEntries(new Headers(headers)) : {};
+  let senderEmail: string | undefined;
 
   const session = {
     url: pkgUrl,
@@ -41,8 +61,11 @@ export async function resolveSigningKeysFromYivi(
       parseResponse: (r: Response) => {
         return r
           .text()
-          .then((jwt: string) =>
-            fetch(`${pkgUrl}/v2/irma/sign/key`, {
+          .then((jwt: string) => {
+            // Extract sender email from the Yivi session JWT
+            senderEmail = extractEmailFromJwt(jwt);
+
+            return fetch(`${pkgUrl}/v2/irma/sign/key`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -52,8 +75,8 @@ export async function resolveSigningKeysFromYivi(
               body: JSON.stringify({
                 pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
               }),
-            })
-          )
+            });
+          })
           .then((r: Response) => r.json());
       },
     },
@@ -82,5 +105,6 @@ export async function resolveSigningKeysFromYivi(
   return {
     pubSignKey: result.pubSignKey,
     privSignKey: result.privSignKey,
+    senderEmail: senderEmail ?? opts.senderEmail,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,8 @@ export interface PolicyEntry {
 export interface SigningKeys {
   pubSignKey: unknown;
   privSignKey?: unknown;
+  /** Email address of the sender, extracted from the Yivi session JWT */
+  senderEmail?: string;
 }
 
 /** PKG session start result */


### PR DESCRIPTION
## Summary
- Extract the sender's email from the Yivi session JWT after signing, storing it in `SigningKeys.senderEmail`
- When `includeSender` is set on a Yivi sign method, add the sender's email to the encryption policy so they can decrypt their own sealed files
- Applies to both `encryptPipeline` and `sealRaw` code paths

## Test plan
- [x] Encrypt with `includeSender: true` and verify the sender can decrypt the result
- [x] Encrypt without `includeSender` and verify sender is not added to the policy
- [x] Verify email extraction works from the Yivi session JWT