### PR TITLE
feat: Support optional attributes in Yivi signing sessions

### DIFF
--- a/src/crypto/signing.ts
+++ b/src/crypto/signing.ts
@@ -16,6 +16,8 @@ export async function resolveSigningKeys(
       return resolveSigningKeysFromYivi(pkgUrl, {
         element: sign.element,
         senderEmail: sign.senderEmail,
+        attributes: sign.attributes,
+        condiscon: sign.condiscon,
         includeSender: sign.includeSender,
       }, headers);
     case 'session':

--- a/src/crypto/signing.ts
+++ b/src/crypto/signing.ts
@@ -16,6 +16,7 @@ export async function resolveSigningKeys(
       return resolveSigningKeysFromYivi(pkgUrl, {
         element: sign.element,
         senderEmail: sign.senderEmail,
+        attributes: sign.attributes,
         includeSender: sign.includeSender,
       }, headers);
     case 'session':

--- a/src/crypto/signing.ts
+++ b/src/crypto/signing.ts
@@ -16,8 +16,6 @@ export async function resolveSigningKeys(
       return resolveSigningKeysFromYivi(pkgUrl, {
         element: sign.element,
         senderEmail: sign.senderEmail,
-        attributes: sign.attributes,
-        condiscon: sign.condiscon,
         includeSender: sign.includeSender,
       }, headers);
     case 'session':

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export type {
   UploadResult,
   // Attribute types
   AttributeCon,
+  AttributeRequest,
+  ConDisCon,
   // Email
   BuildMimeOptions,
   CreateEnvelopeOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,6 @@ export type {
   UploadResult,
   // Attribute types
   AttributeCon,
-  AttributeRequest,
-  ConDisCon,
   // Email
   BuildMimeOptions,
   CreateEnvelopeOptions,

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -29,7 +29,7 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string }[]; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string; optional?: boolean }[]; includeSender?: boolean }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -7,7 +7,6 @@ import type {
   YiviSign,
   SessionSign,
   SessionCallback,
-  ConDisCon,
 } from './types.js';
 import { EmailHelpers } from './email/index.js';
 
@@ -30,7 +29,7 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string; optional?: boolean }[]; condiscon?: ConDisCon; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string }[]; includeSender?: boolean }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -7,6 +7,7 @@ import type {
   YiviSign,
   SessionSign,
   SessionCallback,
+  ConDisCon,
 } from './types.js';
 import { EmailHelpers } from './email/index.js';
 
@@ -29,7 +30,7 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string }[]; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string; optional?: boolean }[]; condiscon?: ConDisCon; includeSender?: boolean }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -1,83 +1,32 @@
 import { YiviCore } from '@privacybydesign/yivi-core';
 import { YiviClient } from '@privacybydesign/yivi-client';
 import { YiviWeb } from '@privacybydesign/yivi-web';
-import type { SigningKeys, ConDisCon, AttributeRequest } from '../types.js';
+import type { SigningKeys } from '../types.js';
 
 export interface YiviSignOptions {
   element: string;
   senderEmail?: string;
-  attributes?: { t: string; v?: string; optional?: boolean }[];
-  condiscon?: ConDisCon;
+  attributes?: { t: string; v?: string }[];
   includeSender?: boolean;
 }
 
-/**
- * Build a condiscon from the simple `attributes` builder format.
- *
- * Email is always added as the first required discon entry.
- * Each attribute becomes its own discon entry:
- * - Required (no value): `[[ { type, notNull: true } ]]`
- * - Required with value: `[[ { type, value } ]]`
- * - Optional: `[ [], [{ type, notNull: true }] ]` (empty first option = user can skip)
- */
-function buildCondiscon(
-  senderEmail?: string,
-  attributes?: { t: string; v?: string; optional?: boolean }[]
-): ConDisCon {
-  const condiscon: ConDisCon = [];
-
-  // Email is always required
-  const emailReq: AttributeRequest = senderEmail
-    ? { type: 'pbdf.sidn-pbdf.email.email', value: senderEmail }
-    : { type: 'pbdf.sidn-pbdf.email.email', notNull: true };
-  condiscon.push([[emailReq]]);
-
-  for (const attr of attributes ?? []) {
-    const req: AttributeRequest = attr.v
-      ? { type: attr.t, value: attr.v }
-      : { type: attr.t, notNull: true };
-
-    if (attr.optional) {
-      // Empty first option means the user may skip this attribute
-      condiscon.push([[], [req]]);
-    } else {
-      condiscon.push([[req]]);
-    }
-  }
-
-  return condiscon;
-}
-
-/** Disclosed attribute extracted from a Yivi session result JWT */
-interface DisclosedAttribute {
-  id: string;
-  value: string;
-}
-
-/**
- * Extract all disclosed attributes from an IRMA/Yivi session result JWT.
- *
- * The JWT payload contains a `disclosed` field which is an array of arrays.
- * Each outer entry corresponds to a discon (disjunction) in the original request.
- * Each inner entry is a disclosed attribute with `id`, `rawvalue`, and `status`.
- * Empty/null groups mean the user skipped an optional discon.
- */
-function extractDisclosedFromJwt(jwt: string): DisclosedAttribute[] {
+/** Extract the sender's email from an IRMA/Yivi session result JWT */
+function extractEmailFromJwt(jwt: string): string | undefined {
   try {
     const payload = JSON.parse(atob(jwt.split('.')[1]));
+    // IRMA session result JWT has disclosed attributes in various formats
     const disclosed: any[][] = payload.disclosed ?? [];
-    const result: DisclosedAttribute[] = [];
     for (const group of disclosed) {
       for (const attr of group) {
-        if (attr.id && (attr.rawvalue != null)) {
-          result.push({ id: attr.id, value: attr.rawvalue });
+        if (attr.id?.endsWith('.email.email') || attr.id?.includes('email')) {
+          return attr.rawvalue ?? attr.value?.[''] ?? attr.value;
         }
       }
     }
-    return result;
   } catch {
-    return [];
+    // JWT decoding failed — not critical, caller handles missing email
   }
+  return undefined;
 }
 
 /** Resolve signing keys via a Yivi session (peer-to-peer sending) */
@@ -89,9 +38,6 @@ export async function resolveSigningKeysFromYivi(
   const extraHeaders = headers ? Object.fromEntries(new Headers(headers)) : {};
   let senderEmail: string | undefined;
 
-  // Build the condiscon: either use the raw condiscon or build from attributes
-  const condiscon = opts.condiscon ?? buildCondiscon(opts.senderEmail, opts.attributes);
-
   const session = {
     url: pkgUrl,
     start: {
@@ -101,7 +47,14 @@ export async function resolveSigningKeysFromYivi(
         'Content-Type': 'application/json',
         ...extraHeaders,
       },
-      body: JSON.stringify({ condiscon }),
+      body: JSON.stringify({
+        con: [
+          opts.senderEmail
+            ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
+            : { t: 'pbdf.sidn-pbdf.email.email' },
+          ...(opts.attributes ?? []),
+        ],
+      }),
     },
     result: {
       url: (o: any, { sessionToken }: any) => `${o.url}/v2/request/jwt/${sessionToken}`,
@@ -109,25 +62,8 @@ export async function resolveSigningKeysFromYivi(
         return r
           .text()
           .then((jwt: string) => {
-            // Extract all disclosed attributes from the session JWT
-            const disclosed = extractDisclosedFromJwt(jwt);
-
-            // Find sender email from disclosed attributes
-            const emailAttr = disclosed.find(a => a.id.endsWith('.email.email') || a.id.includes('email'));
-            senderEmail = emailAttr?.value;
-
-            // Build the signing key request:
-            // - pubSignId: email (always public)
-            // - privSignId: all other disclosed attributes (optional/private)
-            const privAttrs = disclosed.filter(a => !(a.id.endsWith('.email.email') || a.id.includes('email')));
-
-            const keyRequest: Record<string, unknown> = {
-              pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
-            };
-
-            if (privAttrs.length > 0) {
-              keyRequest.privSignId = privAttrs.map(a => ({ t: a.id }));
-            }
+            // Extract sender email from the Yivi session JWT
+            senderEmail = extractEmailFromJwt(jwt);
 
             return fetch(`${pkgUrl}/v2/irma/sign/key`, {
               method: 'POST',
@@ -136,7 +72,9 @@ export async function resolveSigningKeysFromYivi(
                 Authorization: `Bearer ${jwt}`,
                 ...extraHeaders,
               },
-              body: JSON.stringify(keyRequest),
+              body: JSON.stringify({
+                pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
+              }),
             });
           })
           .then((r: Response) => r.json());

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -6,27 +6,36 @@ import type { SigningKeys } from '../types.js';
 export interface YiviSignOptions {
   element: string;
   senderEmail?: string;
-  attributes?: { t: string; v?: string }[];
+  attributes?: { t: string; v?: string; optional?: boolean }[];
   includeSender?: boolean;
 }
 
-/** Extract the sender's email from an IRMA/Yivi session result JWT */
-function extractEmailFromJwt(jwt: string): string | undefined {
+/**
+ * Extract all disclosed attributes from an IRMA/Yivi session result JWT.
+ *
+ * Returns the sender email and a list of all other disclosed attribute type ids.
+ */
+function parseDisclosedJwt(jwt: string): { email?: string; otherAttrTypes: string[] } {
   try {
     const payload = JSON.parse(atob(jwt.split('.')[1]));
-    // IRMA session result JWT has disclosed attributes in various formats
     const disclosed: any[][] = payload.disclosed ?? [];
+    let email: string | undefined;
+    const otherAttrTypes: string[] = [];
+
     for (const group of disclosed) {
       for (const attr of group) {
-        if (attr.id?.endsWith('.email.email') || attr.id?.includes('email')) {
-          return attr.rawvalue ?? attr.value?.[''] ?? attr.value;
+        if (!attr.id || attr.rawvalue == null) continue;
+        if (attr.id.endsWith('.email.email') || attr.id.includes('email')) {
+          email ??= attr.rawvalue ?? attr.value?.[''] ?? attr.value;
+        } else {
+          otherAttrTypes.push(attr.id);
         }
       }
     }
+    return { email, otherAttrTypes };
   } catch {
-    // JWT decoding failed — not critical, caller handles missing email
+    return { otherAttrTypes: [] };
   }
-  return undefined;
 }
 
 /** Resolve signing keys via a Yivi session (peer-to-peer sending) */
@@ -62,8 +71,18 @@ export async function resolveSigningKeysFromYivi(
         return r
           .text()
           .then((jwt: string) => {
-            // Extract sender email from the Yivi session JWT
-            senderEmail = extractEmailFromJwt(jwt);
+            const { email, otherAttrTypes } = parseDisclosedJwt(jwt);
+            senderEmail = email;
+
+            // Build signing key request:
+            // - pubSignId: email (always public)
+            // - privSignId: any other disclosed attributes (optional sender identity)
+            const keyRequest: Record<string, unknown> = {
+              pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
+            };
+            if (otherAttrTypes.length > 0) {
+              keyRequest.privSignId = otherAttrTypes.map(t => ({ t }));
+            }
 
             return fetch(`${pkgUrl}/v2/irma/sign/key`, {
               method: 'POST',
@@ -72,9 +91,7 @@ export async function resolveSigningKeysFromYivi(
                 Authorization: `Bearer ${jwt}`,
                 ...extraHeaders,
               },
-              body: JSON.stringify({
-                pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
-              }),
+              body: JSON.stringify(keyRequest),
             });
           })
           .then((r: Response) => r.json());

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -1,32 +1,83 @@
 import { YiviCore } from '@privacybydesign/yivi-core';
 import { YiviClient } from '@privacybydesign/yivi-client';
 import { YiviWeb } from '@privacybydesign/yivi-web';
-import type { SigningKeys } from '../types.js';
+import type { SigningKeys, ConDisCon, AttributeRequest } from '../types.js';
 
 export interface YiviSignOptions {
   element: string;
   senderEmail?: string;
-  attributes?: { t: string; v?: string }[];
+  attributes?: { t: string; v?: string; optional?: boolean }[];
+  condiscon?: ConDisCon;
   includeSender?: boolean;
 }
 
-/** Extract the sender's email from an IRMA/Yivi session result JWT */
-function extractEmailFromJwt(jwt: string): string | undefined {
+/**
+ * Build a condiscon from the simple `attributes` builder format.
+ *
+ * Email is always added as the first required discon entry.
+ * Each attribute becomes its own discon entry:
+ * - Required (no value): `[[ { type, notNull: true } ]]`
+ * - Required with value: `[[ { type, value } ]]`
+ * - Optional: `[ [], [{ type, notNull: true }] ]` (empty first option = user can skip)
+ */
+function buildCondiscon(
+  senderEmail?: string,
+  attributes?: { t: string; v?: string; optional?: boolean }[]
+): ConDisCon {
+  const condiscon: ConDisCon = [];
+
+  // Email is always required
+  const emailReq: AttributeRequest = senderEmail
+    ? { type: 'pbdf.sidn-pbdf.email.email', value: senderEmail }
+    : { type: 'pbdf.sidn-pbdf.email.email', notNull: true };
+  condiscon.push([[emailReq]]);
+
+  for (const attr of attributes ?? []) {
+    const req: AttributeRequest = attr.v
+      ? { type: attr.t, value: attr.v }
+      : { type: attr.t, notNull: true };
+
+    if (attr.optional) {
+      // Empty first option means the user may skip this attribute
+      condiscon.push([[], [req]]);
+    } else {
+      condiscon.push([[req]]);
+    }
+  }
+
+  return condiscon;
+}
+
+/** Disclosed attribute extracted from a Yivi session result JWT */
+interface DisclosedAttribute {
+  id: string;
+  value: string;
+}
+
+/**
+ * Extract all disclosed attributes from an IRMA/Yivi session result JWT.
+ *
+ * The JWT payload contains a `disclosed` field which is an array of arrays.
+ * Each outer entry corresponds to a discon (disjunction) in the original request.
+ * Each inner entry is a disclosed attribute with `id`, `rawvalue`, and `status`.
+ * Empty/null groups mean the user skipped an optional discon.
+ */
+function extractDisclosedFromJwt(jwt: string): DisclosedAttribute[] {
   try {
     const payload = JSON.parse(atob(jwt.split('.')[1]));
-    // IRMA session result JWT has disclosed attributes in various formats
     const disclosed: any[][] = payload.disclosed ?? [];
+    const result: DisclosedAttribute[] = [];
     for (const group of disclosed) {
       for (const attr of group) {
-        if (attr.id?.endsWith('.email.email') || attr.id?.includes('email')) {
-          return attr.rawvalue ?? attr.value?.[''] ?? attr.value;
+        if (attr.id && (attr.rawvalue != null)) {
+          result.push({ id: attr.id, value: attr.rawvalue });
         }
       }
     }
+    return result;
   } catch {
-    // JWT decoding failed — not critical, caller handles missing email
+    return [];
   }
-  return undefined;
 }
 
 /** Resolve signing keys via a Yivi session (peer-to-peer sending) */
@@ -38,6 +89,9 @@ export async function resolveSigningKeysFromYivi(
   const extraHeaders = headers ? Object.fromEntries(new Headers(headers)) : {};
   let senderEmail: string | undefined;
 
+  // Build the condiscon: either use the raw condiscon or build from attributes
+  const condiscon = opts.condiscon ?? buildCondiscon(opts.senderEmail, opts.attributes);
+
   const session = {
     url: pkgUrl,
     start: {
@@ -47,14 +101,7 @@ export async function resolveSigningKeysFromYivi(
         'Content-Type': 'application/json',
         ...extraHeaders,
       },
-      body: JSON.stringify({
-        con: [
-          opts.senderEmail
-            ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
-            : { t: 'pbdf.sidn-pbdf.email.email' },
-          ...(opts.attributes ?? []),
-        ],
-      }),
+      body: JSON.stringify({ condiscon }),
     },
     result: {
       url: (o: any, { sessionToken }: any) => `${o.url}/v2/request/jwt/${sessionToken}`,
@@ -62,8 +109,25 @@ export async function resolveSigningKeysFromYivi(
         return r
           .text()
           .then((jwt: string) => {
-            // Extract sender email from the Yivi session JWT
-            senderEmail = extractEmailFromJwt(jwt);
+            // Extract all disclosed attributes from the session JWT
+            const disclosed = extractDisclosedFromJwt(jwt);
+
+            // Find sender email from disclosed attributes
+            const emailAttr = disclosed.find(a => a.id.endsWith('.email.email') || a.id.includes('email'));
+            senderEmail = emailAttr?.value;
+
+            // Build the signing key request:
+            // - pubSignId: email (always public)
+            // - privSignId: all other disclosed attributes (optional/private)
+            const privAttrs = disclosed.filter(a => !(a.id.endsWith('.email.email') || a.id.includes('email')));
+
+            const keyRequest: Record<string, unknown> = {
+              pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
+            };
+
+            if (privAttrs.length > 0) {
+              keyRequest.privSignId = privAttrs.map(a => ({ t: a.id }));
+            }
 
             return fetch(`${pkgUrl}/v2/irma/sign/key`, {
               method: 'POST',
@@ -72,9 +136,7 @@ export async function resolveSigningKeysFromYivi(
                 Authorization: `Bearer ${jwt}`,
                 ...extraHeaders,
               },
-              body: JSON.stringify({
-                pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
-              }),
+              body: JSON.stringify(keyRequest),
             });
           })
           .then((r: Response) => r.json());

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,14 +40,51 @@ export interface ApiKeySign {
   apiKey: string;
 }
 
+// --- Condiscon types ---
+
+/**
+ * A single attribute request in the IRMA condiscon format.
+ *
+ * - `string`: shorthand for requesting any value of that attribute type
+ * - `object`: request with optional value constraint and notNull flag
+ */
+export type AttributeRequest =
+  | string
+  | { type: string; value?: string; notNull?: boolean };
+
+/**
+ * IRMA ConDisCon: conjunction of disjunctions of conjunctions.
+ *
+ * Structure: `AttributeRequest[][][]`
+ * - Outer array: conjunction (AND) — user must satisfy ALL entries
+ * - Middle array: disjunction (OR) — user picks ONE option
+ * - Inner array: inner conjunction — attributes grouped from one credential
+ *
+ * An empty inner conjunction (`[]`) as the first option in a disjunction
+ * makes that disjunction optional (user may skip it).
+ *
+ * @example
+ * // Email required, fullname optional:
+ * [
+ *   [[ { type: 'pbdf.sidn-pbdf.email.email', notNull: true } ]],
+ *   [ [], [{ type: 'pbdf.gemeente.personalData.fullname', notNull: true }] ],
+ * ]
+ */
+export type ConDisCon = AttributeRequest[][][];
+
 /** Signing via Yivi session (peer-to-peer) */
 export interface YiviSign {
   type: 'yivi';
   element: string;
   senderEmail?: string;
-  /** Additional attributes to request in the Yivi session (e.g. name).
-   *  Email is always included automatically. */
-  attributes?: { t: string; v?: string }[];
+  /** Simple builder: each attribute becomes its own discon entry.
+   *  Email is always included automatically. Mark as optional to let the user skip.
+   *  Mutually exclusive with `condiscon`. */
+  attributes?: { t: string; v?: string; optional?: boolean }[];
+  /** Advanced: raw condiscon disclosure request. Gives full control over the
+   *  IRMA session structure (e.g. multi-credential-source disjunctions).
+   *  When provided, `attributes` is ignored and email is NOT auto-added. */
+  condiscon?: ConDisCon;
   includeSender?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,51 +40,14 @@ export interface ApiKeySign {
   apiKey: string;
 }
 
-// --- Condiscon types ---
-
-/**
- * A single attribute request in the IRMA condiscon format.
- *
- * - `string`: shorthand for requesting any value of that attribute type
- * - `object`: request with optional value constraint and notNull flag
- */
-export type AttributeRequest =
-  | string
-  | { type: string; value?: string; notNull?: boolean };
-
-/**
- * IRMA ConDisCon: conjunction of disjunctions of conjunctions.
- *
- * Structure: `AttributeRequest[][][]`
- * - Outer array: conjunction (AND) — user must satisfy ALL entries
- * - Middle array: disjunction (OR) — user picks ONE option
- * - Inner array: inner conjunction — attributes grouped from one credential
- *
- * An empty inner conjunction (`[]`) as the first option in a disjunction
- * makes that disjunction optional (user may skip it).
- *
- * @example
- * // Email required, fullname optional:
- * [
- *   [[ { type: 'pbdf.sidn-pbdf.email.email', notNull: true } ]],
- *   [ [], [{ type: 'pbdf.gemeente.personalData.fullname', notNull: true }] ],
- * ]
- */
-export type ConDisCon = AttributeRequest[][][];
-
 /** Signing via Yivi session (peer-to-peer) */
 export interface YiviSign {
   type: 'yivi';
   element: string;
   senderEmail?: string;
-  /** Simple builder: each attribute becomes its own discon entry.
-   *  Email is always included automatically. Mark as optional to let the user skip.
-   *  Mutually exclusive with `condiscon`. */
-  attributes?: { t: string; v?: string; optional?: boolean }[];
-  /** Advanced: raw condiscon disclosure request. Gives full control over the
-   *  IRMA session structure (e.g. multi-credential-source disjunctions).
-   *  When provided, `attributes` is ignored and email is NOT auto-added. */
-  condiscon?: ConDisCon;
+  /** Additional attributes to request in the Yivi session (e.g. name).
+   *  Email is always included automatically. */
+  attributes?: { t: string; v?: string }[];
   includeSender?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,8 +46,8 @@ export interface YiviSign {
   element: string;
   senderEmail?: string;
   /** Additional attributes to request in the Yivi session (e.g. name).
-   *  Email is always included automatically. */
-  attributes?: { t: string; v?: string }[];
+   *  Email is always included automatically. Mark as optional to let the user skip. */
+  attributes?: { t: string; v?: string; optional?: boolean }[];
   includeSender?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Support optional additional attributes in Yivi signing sessions beyond the default email attribute
- Make `senderEmail` optional in `YiviSign`, allowing attribute disclosure without a pre-set value
- Pass extra attributes from `YiviSignOptions` into the signing session request

## Test plan
- [ ] Verify signing works with additional `attributes` passed (e.g. name)
- [ ] Verify signing works with only `senderEmail` (backwards compatible)
- [ ] Verify signing works with `senderEmail` omitted