### PR TITLE
feat: replace withPolicy with fluent RecipientBuilder.extraAttribute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,37 +24,43 @@ const pg = new PostGuard({
 });
 ```
 
-## Supported Flows
+## Architecture
 
-| Flow | Method | Description |
-|------|--------|-------------|
-| Yivi → Yivi | `encryptAndUpload` | Peer-to-peer: sender signs with Yivi, recipient decrypts with Yivi |
-| API → Yivi (with email) | `encryptAndDeliver` | Business signs with API key, Cryptify sends email notification |
-| API → Yivi (no email) | `encryptAndUpload` | Business signs with API key, returns UUID for custom delivery |
-| Raw encrypt | `encrypt` | Encrypt raw data (for email addons, custom transports) |
-| Raw decrypt | `decrypt({ data })` | Decrypt raw data (for email addons) |
+The SDK uses a lazy builder pattern. `pg.encrypt()` and `pg.open()` return builder objects that capture parameters but do no work. The actual operation runs when you call a terminal method.
+
+```ts
+// Encrypt: nothing happens until .upload() or .toBytes()
+const sealed = pg.encrypt({ files, recipients, sign });
+await sealed.upload();                                // encrypt + stream to Cryptify
+await sealed.upload({ notify: { message: 'Hi' } });  // + email notification
+const bytes = await sealed.toBytes();                 // encrypt + buffer in memory
+
+// Decrypt: nothing happens until .inspect() or .decrypt()
+const opened = pg.open({ uuid });
+const info = await opened.inspect();                  // peek at recipients and sender
+const result = await opened.decrypt({ element: '#yivi-web' });
+result.download();
+```
 
 ## Encryption
 
 ### Encrypt files + upload to Cryptify
 
 ```ts
-const { uuid } = await pg.encryptAndUpload({
+const sealed = pg.encrypt({
   sign: pg.sign.apiKey('your-api-key'),
   recipients: [pg.recipient.email('bob@example.com')],
   files: fileList,
   onProgress: (pct) => console.log(`${pct}%`),
+  signal: abortController.signal,
 });
-```
 
-### Encrypt files + upload + email delivery
+// Upload only (returns UUID for custom delivery)
+const { uuid } = await sealed.upload();
 
-```ts
-const { uuid } = await pg.encryptAndDeliver({
-  sign: pg.sign.apiKey('your-api-key'),
-  recipients: [pg.recipient.email('bob@example.com')],
-  files: fileList,
-  delivery: { message: 'Here are your documents.', language: 'EN' },
+// Upload and have Cryptify send email notifications
+const { uuid } = await sealed.upload({
+  notify: { message: 'Here are your documents.', language: 'EN' },
 });
 ```
 
@@ -63,23 +69,35 @@ const { uuid } = await pg.encryptAndDeliver({
 For email clients and custom integrations that handle their own transport:
 
 ```ts
-const encrypted = await pg.encrypt({
+const sealed = pg.encrypt({
   sign: pg.sign.apiKey('your-api-key'),
   recipients: [pg.recipient.email('bob@example.com')],
   data: myDataBytes, // Uint8Array or ReadableStream
 });
+
+const encrypted = await sealed.toBytes();
 // encrypted is a Uint8Array — attach it, send it, store it however you want
 ```
 
 ## Decryption
 
+### Inspect before decrypt
+
+```ts
+const opened = pg.open({ uuid: 'the-file-uuid' });
+const info = await opened.inspect();
+// info.recipients: ['bob@example.com']
+// info.sender: { email: 'alice@example.com', attributes: [...] }
+```
+
 ### Decrypt from Cryptify UUID (Yivi web)
 
 ```ts
-const result = await pg.decrypt({
-  uuid: 'the-file-uuid',
+const opened = pg.open({ uuid: 'the-file-uuid' });
+const result = await opened.decrypt({
   element: '#yivi-popup',
   recipient: 'bob@example.com', // optional hint
+  enableCache: true,            // cache JWT for repeated decryptions
 });
 
 result.download('decrypted-files.zip');
@@ -89,8 +107,8 @@ console.log('Sender:', result.sender);
 ### Decrypt raw data
 
 ```ts
-const result = await pg.decrypt({
-  data: encryptedBytes,
+const opened = pg.open({ data: encryptedBytes });
+const result = await opened.decrypt({
   element: '#yivi-popup',
   recipient: 'bob@example.com',
 });
@@ -105,7 +123,15 @@ const result = await pg.decrypt({
 pg.sign.apiKey('your-api-key')
 
 // Yivi web session (browser, inline QR code)
-pg.sign.yivi({ element: '#yivi-popup', senderEmail: 'alice@example.com' })
+pg.sign.yivi({
+  element: '#yivi-popup',
+  senderEmail: 'alice@example.com',
+  attributes: [                    // optional: request extra attributes
+    { t: 'pbdf.gemeente.personalData.fullname', optional: true },
+    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', optional: true },
+  ],
+  includeSender: true,             // optional: also encrypt for the sender
+})
 
 // Custom session callback (email addons, mobile apps, etc.)
 pg.sign.session(
@@ -126,11 +152,10 @@ pg.recipient.email('bob@example.com')
 // Encrypt for anyone with an email at a domain
 pg.recipient.emailDomain('bob@example-org.com')
 
-// Encrypt with custom attribute policy
-pg.recipient.withPolicy('bob@example.com', [
-  { t: 'pbdf.sidn-pbdf.email.email', v: 'bob@example.com' },
-  { t: 'pbdf.gemeente.personalData.surname', v: 'Smith' },
-])
+// Require extra attributes (fluent chaining)
+pg.recipient.email('bob@example.com')
+  .extraAttribute('pbdf.gemeente.personalData.surname', 'Smith')
+  .extraAttribute('pbdf.sidn-pbdf.mobilenumber.mobilenumber', '0612345678')
 ```
 
 ## Email Integration
@@ -139,7 +164,7 @@ For email clients (Thunderbird, Outlook, etc.) that need to encrypt/decrypt emai
 
 ```ts
 // Build inner MIME message
-const mime = pg.email.buildMime({
+const mime = buildMime({
   from: 'alice@example.com',
   to: ['bob@example.com'],
   subject: 'Hello',
@@ -147,15 +172,14 @@ const mime = pg.email.buildMime({
   attachments: [{ name: 'doc.pdf', type: 'application/pdf', data: pdfBuffer }],
 });
 
-// Encrypt the MIME content
-const encrypted = await pg.encrypt({
-  sign: pg.sign.session(myYiviHandler, { senderEmail: 'alice@example.com' }),
+// Encrypt the MIME content and create email envelope
+const sealed = pg.encrypt({
+  sign: pg.sign.yivi({ element: '#yivi-popup', senderEmail: 'alice@example.com' }),
   recipients: [pg.recipient.email('bob@example.com')],
   data: mime,
 });
 
-// Create the encrypted email envelope (placeholder HTML + attachment)
-const envelope = pg.email.createEnvelope({ encrypted, from: 'alice@example.com' });
+const envelope = await pg.email.createEnvelope({ sealed, from: 'alice@example.com' });
 // envelope.subject → "PostGuard Encrypted Email"
 // envelope.htmlBody → Placeholder HTML with PostGuard branding
 // envelope.plainTextBody → Plain text fallback
@@ -164,19 +188,25 @@ const envelope = pg.email.createEnvelope({ encrypted, from: 'alice@example.com' 
 // --- On the receiving side ---
 
 // Extract ciphertext from a received email
-const ciphertext = pg.email.extractCiphertext({
+const ciphertext = extractCiphertext({
   htmlBody: emailBodyHtml,
   attachments: [{ name: 'postguard.encrypted', data: attachmentBuffer }],
 });
 
 // Decrypt
-const result = await pg.decrypt({
-  data: ciphertext,
+const opened = pg.open({ data: ciphertext });
+const result = await opened.decrypt({
+  element: '#yivi-popup',
   recipient: 'bob@example.com',
-  session: async ({ con, sort, hints }) => myYiviHandler(con, sort, hints),
 });
 // result.plaintext → decrypted MIME content
 // result.sender → verified sender identity
+```
+
+Standalone email helpers (`buildMime`, `extractCiphertext`, `injectMimeHeaders`) can be imported directly without creating a PostGuard instance:
+
+```ts
+import { buildMime, extractCiphertext, injectMimeHeaders } from '@e4a/pg-js';
 ```
 
 ## Error Handling
@@ -191,7 +221,7 @@ import {
 } from '@e4a/pg-js';
 
 try {
-  await pg.encrypt(options);
+  await sealed.upload();
 } catch (err) {
   if (err instanceof IdentityMismatchError) {
     // Yivi attributes didn't match the encryption policy

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,14 @@ export { PostGuard } from './postguard.js';
 export { Sealed } from './sealed.js';
 export { Opened } from './opened.js';
 
+// Recipient builder
+export { RecipientBuilder } from './recipients/builder.js';
+
 // Types consumers need
 export type {
   PostGuardConfig,
   // Recipients
   Recipient,
-  EmailRecipient,
-  EmailDomainRecipient,
-  CustomPolicyRecipient,
   // Signing
   SignMethod,
   ApiKeySign,

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -1,13 +1,11 @@
 import type {
   PostGuardConfig,
-  EmailRecipient,
-  EmailDomainRecipient,
-  CustomPolicyRecipient,
   ApiKeySign,
   YiviSign,
   SessionSign,
   SessionCallback,
 } from './types.js';
+import { RecipientBuilder } from './recipients/builder.js';
 import { EmailHelpers } from './email/index.js';
 
 /** Base class with config, builders, and email helpers shared by PostGuard variants. */
@@ -29,7 +27,7 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string }[]; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string; optional?: boolean }[]; includeSender?: boolean }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),
@@ -42,18 +40,9 @@ export class PostGuardBase {
 
   /** Recipient builders */
   readonly recipient = {
-    email: (email: string): EmailRecipient => ({
-      type: 'email',
-      email,
-    }),
-    emailDomain: (email: string): EmailDomainRecipient => ({
-      type: 'emailDomain',
-      email,
-    }),
-    withPolicy: (email: string, policy: { t: string; v: string }[]): CustomPolicyRecipient => ({
-      type: 'customPolicy',
-      email,
-      policy,
-    }),
+    email: (email: string): RecipientBuilder =>
+      new RecipientBuilder(email, 'email'),
+    emailDomain: (email: string): RecipientBuilder =>
+      new RecipientBuilder(email, 'emailDomain'),
   };
 }

--- a/src/recipients/builder.ts
+++ b/src/recipients/builder.ts
@@ -1,0 +1,20 @@
+/** Fluent builder for creating a recipient with attribute constraints. */
+export class RecipientBuilder {
+  readonly email: string;
+  /** @internal */
+  readonly _baseType: 'email' | 'emailDomain';
+  /** @internal */
+  readonly _extras: { t: string; v: string }[] = [];
+
+  /** @internal */
+  constructor(email: string, baseType: 'email' | 'emailDomain') {
+    this.email = email;
+    this._baseType = baseType;
+  }
+
+  /** Add an extra attribute the recipient must prove to decrypt. */
+  extraAttribute(type: string, value: string): this {
+    this._extras.push({ t: type, v: value });
+    return this;
+  }
+}

--- a/src/recipients/builders.ts
+++ b/src/recipients/builders.ts
@@ -4,6 +4,16 @@ function extractDomain(email: string): string {
   return email.split('@')[1] || '';
 }
 
+/** Build the full attribute constraint list for a recipient. */
+function buildCon(r: Recipient): { t: string; v: string }[] {
+  const base =
+    r._baseType === 'email'
+      ? [{ t: 'pbdf.sidn-pbdf.email.email', v: r.email }]
+      : [{ t: 'pbdf.sidn-pbdf.email.domain', v: extractDomain(r.email) }];
+
+  return [...base, ...r._extras];
+}
+
 /** Build an encryption policy map from a list of recipients */
 export function buildEncryptionPolicy(
   recipients: Recipient[],
@@ -12,26 +22,10 @@ export function buildEncryptionPolicy(
   const policy: Record<string, PolicyEntry> = {};
 
   for (const r of recipients) {
-    switch (r.type) {
-      case 'email':
-        policy[r.email] = {
-          ts: timestamp,
-          con: [{ t: 'pbdf.sidn-pbdf.email.email', v: r.email }],
-        };
-        break;
-      case 'emailDomain':
-        policy[r.email] = {
-          ts: timestamp,
-          con: [{ t: 'pbdf.sidn-pbdf.email.domain', v: extractDomain(r.email) }],
-        };
-        break;
-      case 'customPolicy':
-        policy[r.email] = {
-          ts: timestamp,
-          con: r.policy,
-        };
-        break;
-    }
+    policy[r.email] = {
+      ts: timestamp,
+      con: buildCon(r),
+    };
   }
 
   return policy;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,26 +11,9 @@ export interface PostGuardConfig {
 
 // --- Recipients ---
 
-/** A recipient identified by exact email address (citizen) */
-export interface EmailRecipient {
-  type: 'email';
-  email: string;
-}
+import { RecipientBuilder } from './recipients/builder.js';
 
-/** A recipient identified by email domain (organisation) */
-export interface EmailDomainRecipient {
-  type: 'emailDomain';
-  email: string;
-}
-
-/** A recipient with a custom attribute policy */
-export interface CustomPolicyRecipient {
-  type: 'customPolicy';
-  email: string;
-  policy: { t: string; v: string }[];
-}
-
-export type Recipient = EmailRecipient | EmailDomainRecipient | CustomPolicyRecipient;
+export type Recipient = RecipientBuilder;
 
 // --- Signing ---
 

--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PostGuard } from '../src/postguard.js';
+import { RecipientBuilder } from '../src/recipients/builder.js';
 
 describe('PostGuard', () => {
   const pg = new PostGuard({
@@ -36,12 +37,27 @@ describe('PostGuard', () => {
   describe('recipient builders', () => {
     it('builds email recipient', () => {
       const r = pg.recipient.email('alice@example.com');
-      expect(r).toEqual({ type: 'email', email: 'alice@example.com' });
+      expect(r).toBeInstanceOf(RecipientBuilder);
+      expect(r.email).toBe('alice@example.com');
+      expect(r._baseType).toBe('email');
     });
 
     it('builds emailDomain recipient', () => {
       const r = pg.recipient.emailDomain('bob@corp.com');
-      expect(r).toEqual({ type: 'emailDomain', email: 'bob@corp.com' });
+      expect(r).toBeInstanceOf(RecipientBuilder);
+      expect(r.email).toBe('bob@corp.com');
+      expect(r._baseType).toBe('emailDomain');
+    });
+
+    it('chains extraAttribute calls', () => {
+      const r = pg.recipient.email('alice@example.com')
+        .extraAttribute('pbdf.gemeente.personalData.surname', 'Smith')
+        .extraAttribute('pbdf.sidn-pbdf.mobilenumber.mobilenumber', '0612345678');
+
+      expect(r._extras).toEqual([
+        { t: 'pbdf.gemeente.personalData.surname', v: 'Smith' },
+        { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '0612345678' },
+      ]);
     });
   });
 });

--- a/tests/recipients.test.ts
+++ b/tests/recipients.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { buildEncryptionPolicy } from '../src/recipients/builders.js';
-import type { Recipient } from '../src/types.js';
+import { RecipientBuilder } from '../src/recipients/builder.js';
 
 describe('buildEncryptionPolicy', () => {
   const ts = 1700000000;
 
   it('builds policy for email recipients', () => {
-    const recipients: Recipient[] = [{ type: 'email', email: 'alice@example.com' }];
+    const recipients = [new RecipientBuilder('alice@example.com', 'email')];
     const policy = buildEncryptionPolicy(recipients, ts);
 
     expect(policy).toEqual({
@@ -18,7 +18,7 @@ describe('buildEncryptionPolicy', () => {
   });
 
   it('builds policy for emailDomain recipients', () => {
-    const recipients: Recipient[] = [{ type: 'emailDomain', email: 'bob@corp.com' }];
+    const recipients = [new RecipientBuilder('bob@corp.com', 'emailDomain')];
     const policy = buildEncryptionPolicy(recipients, ts);
 
     expect(policy).toEqual({
@@ -30,15 +30,26 @@ describe('buildEncryptionPolicy', () => {
   });
 
   it('handles multiple recipients of mixed types', () => {
-    const recipients: Recipient[] = [
-      { type: 'email', email: 'alice@example.com' },
-      { type: 'emailDomain', email: 'bob@corp.com' },
+    const recipients = [
+      new RecipientBuilder('alice@example.com', 'email'),
+      new RecipientBuilder('bob@corp.com', 'emailDomain'),
     ];
     const policy = buildEncryptionPolicy(recipients, ts);
 
     expect(Object.keys(policy)).toHaveLength(2);
     expect(policy['alice@example.com'].con[0].t).toBe('pbdf.sidn-pbdf.email.email');
     expect(policy['bob@corp.com'].con[0].t).toBe('pbdf.sidn-pbdf.email.domain');
+  });
+
+  it('includes extra attributes in policy', () => {
+    const r = new RecipientBuilder('alice@example.com', 'email')
+      .extraAttribute('pbdf.gemeente.personalData.surname', 'Smith');
+    const policy = buildEncryptionPolicy([r], ts);
+
+    expect(policy['alice@example.com'].con).toEqual([
+      { t: 'pbdf.sidn-pbdf.email.email', v: 'alice@example.com' },
+      { t: 'pbdf.gemeente.personalData.surname', v: 'Smith' },
+    ]);
   });
 
   it('returns empty policy for empty recipients', () => {


### PR DESCRIPTION
Simplify the recipient API from three separate types (EmailRecipient, EmailDomainRecipient, CustomPolicyRecipient) to a single RecipientBuilder class with fluent .extraAttribute(type, value) chaining:

  pg.recipient.email('bob@example.com')
    .extraAttribute('pbdf.gemeente.personalData.surname', 'Smith')

Also updates README to the current builder pattern API.