### PR TITLE
fix: await pipeTo to prevent upload UUID race condition

### DIFF
--- a/src/crypto/chunker.ts
+++ b/src/crypto/chunker.ts
@@ -40,13 +40,16 @@ export default class Chunker extends TransformStream<Uint8Array, Uint8Array> {
   }
 }
 
+export interface TransformResult {
+  writable: WritableStream<Uint8Array>;
+  pipeDone: Promise<void>;
+}
+
 export function withTransform(
   writable: WritableStream<Uint8Array>,
   transform: TransformStream<Uint8Array, Uint8Array>,
   signal: AbortSignal
-): WritableStream<Uint8Array> {
-  transform.readable.pipeTo(writable, { signal }).catch((err) => {
-    console.error('Error in withTransform pipe:', err);
-  });
-  return transform.writable;
+): TransformResult {
+  const pipeDone = transform.readable.pipeTo(writable, { signal });
+  return { writable: transform.writable, pipeDone };
 }

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -87,14 +87,11 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   });
 
   const uploadChunker = new Chunker(UPLOAD_CHUNK_SIZE);
+  const { writable, pipeDone } = withTransform(uploadStream.writable, uploadChunker, effectiveSignal);
 
   // Encrypt: ZIP -> sealStream -> chunker -> upload
-  await sealStream(
-    mpk,
-    sealOptions,
-    readable,
-    withTransform(uploadStream.writable, uploadChunker, effectiveSignal)
-  );
+  await sealStream(mpk, sealOptions, readable, writable);
+  await pipeDone;
 
   return { uuid: uploadStream.getUuid() };
 }


### PR DESCRIPTION
## Summary
- `withTransform` called `pipeTo` fire-and-forget, causing a race condition where `getUuid()` could be called before `initUpload` resolved
- Now returns the `pipeTo` promise as `pipeDone` so the caller can await the full pipe chain before reading the UUID

## Root cause
The upload stream's `start()` method calls `initUpload` (a network request) which sets the UUID. But `pipeTo` was not awaited, so `sealStream` could complete and `getUuid()` could run before `start()` finished — returning an empty string.

## Test plan
- [x] Encrypt & send a file via the SvelteKit example, verify the UUID is displayed in the success state
- [x] Encrypt & upload (upload-only mode), verify the UUID and download link are displayed