### PR TITLE
feat: fluent RecipientBuilder, fix pipe handling, redesign email template

### DIFF
--- a/src/crypto/chunker.ts
+++ b/src/crypto/chunker.ts
@@ -40,13 +40,16 @@ export default class Chunker extends TransformStream<Uint8Array, Uint8Array> {
   }
 }
 
+export interface TransformResult {
+  writable: WritableStream<Uint8Array>;
+  pipeDone: Promise<void>;
+}
+
 export function withTransform(
   writable: WritableStream<Uint8Array>,
   transform: TransformStream<Uint8Array, Uint8Array>,
   signal: AbortSignal
-): WritableStream<Uint8Array> {
-  transform.readable.pipeTo(writable, { signal }).catch((err) => {
-    console.error('Error in withTransform pipe:', err);
-  });
-  return transform.writable;
+): TransformResult {
+  const pipeDone = transform.readable.pipeTo(writable, { signal });
+  return { writable: transform.writable, pipeDone };
 }

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -78,14 +78,11 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   });
 
   const uploadChunker = new Chunker(UPLOAD_CHUNK_SIZE);
+  const { writable, pipeDone } = withTransform(uploadStream.writable, uploadChunker, effectiveSignal);
 
   // Encrypt: ZIP -> sealStream -> chunker -> upload
-  await sealStream(
-    mpk,
-    sealOptions,
-    readable,
-    withTransform(uploadStream.writable, uploadChunker, effectiveSignal)
-  );
+  await sealStream(mpk, sealOptions, readable, writable);
+  await pipeDone;
 
   return { uuid: uploadStream.getUuid() };
 }

--- a/src/email/envelope.ts
+++ b/src/email/envelope.ts
@@ -60,16 +60,24 @@ export async function createEnvelope(options: CreateEnvelopeOptions): Promise<En
             </div>
             <div style="background:#FFFFFF;padding:60px 50px;border-radius:8px;text-align:center;">
                 <p style="font-size:22px;font-weight:700;color:#030E17;margin:0 0 5px 0;line-height:30px;">
-                    ${escapeHtml(from)}
+                    You received an encrypted email
                 </p>
-                <p style="font-size:16px;color:#5F7381;margin:15px 0 0 0;">
-                    sent you an encrypted email via PostGuard.
-                </p>${messageSection}
-                <p style="font-size:14px;color:#5F7381;margin:25px 0 0 0;">
-                    To decrypt this message, you need the
-                    <a href="${websiteUrl}" style="color:#3095DE;text-decoration:none;font-weight:600;">PostGuard</a>
-                    extension for Thunderbird.
-                </p>${fallbackLink}
+                <p style="font-size:14px;color:#5F7381;margin:15px 0 0 0;">
+                    This email is protected with PostGuard encryption.
+                </p>${messageSection}${fallbackLink}
+                <div style="text-align:left;padding-top:30px;">
+                    <p style="color:#5F7381;font-size:16px;font-weight:600;margin:0 0 4px 0;">Or visit</p>
+                    <a style="color:#3095DE;font-size:13px;font-weight:400;line-height:18px;word-break:break-all;" href="${websiteUrl}">
+                        ${websiteUrl}
+                    </a>
+                </div>
+                <div style="margin-top:40px;padding-top:30px;border-top:1px solid #C6E2F6;text-align:center;">
+                    <div style="margin-bottom:12px;">
+                        <span style="display:inline-block;width:32px;height:32px;line-height:32px;border-radius:50%;border:2px solid #5F7381;text-align:center;font-size:16px;color:#5F7381;box-sizing:border-box;">&#10003;</span>
+                    </div>
+                    <p style="font-size:13px;color:#5F7381;margin:0 0 6px 0;">Sent by</p>
+                    <p style="font-size:15px;font-weight:700;color:#030E17;margin:0 0 12px 0;">${escapeHtml(from)}</p>
+                </div>
             </div>
             <div style="height:40px;"></div>
         </div>


### PR DESCRIPTION
## Summary
- Replace `withPolicy` with a fluent `RecipientBuilder.extraAttribute()` API for configuring recipients
- Fix `withTransform` to return and await a `pipeDone` promise, properly propagating pipe errors instead of silently catching them
- Redesign the HTML fallback email envelope with a cleaner layout and sender info in a footer section

## Test plan
- [ ] Verify encryption pipeline completes without errors (pipe completion is now awaited)
- [ ] Confirm `RecipientBuilder.extraAttribute()` works as expected in tests
- [ ] Check fallback email HTML renders correctly in email clients