### PR TITLE
fix: cache signing keys in Sealed to prevent duplicate Yivi sessions

### DIFF
--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -24,6 +24,8 @@ export interface EncryptPipelineOptions {
     confirmToSender?: boolean;
   };
   headers?: HeadersInit;
+  /** Pre-resolved signing keys (skips Yivi/API key resolution if provided) */
+  signingKeys?: SigningKeys;
 }
 
 /** Full encryption pipeline: sign -> policy -> ZIP -> seal -> upload */
@@ -38,7 +40,7 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   // Fetch MPK and signing keys in parallel
   const [mpk, signingKeys] = await Promise.all([
     fetchMPK(pkgUrl, headers),
-    resolveSigningKeys(pkgUrl, sign, headers),
+    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers),
   ]);
 
   // Build encryption policy
@@ -102,6 +104,8 @@ export interface SealRawOptions {
   recipients: Recipient[];
   data: Uint8Array | ReadableStream<Uint8Array>;
   headers?: HeadersInit;
+  /** Pre-resolved signing keys (skips Yivi/API key resolution if provided) */
+  signingKeys?: SigningKeys;
 }
 
 /** Seal raw data: sign -> policy -> sealStream -> return encrypted bytes */
@@ -111,7 +115,7 @@ export async function sealRaw(options: SealRawOptions): Promise<Uint8Array> {
   // Fetch MPK and signing keys in parallel
   const [mpk, signingKeys] = await Promise.all([
     fetchMPK(pkgUrl, headers),
-    resolveSigningKeys(pkgUrl, sign, headers),
+    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers),
   ]);
 
   // Build encryption policy

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -1,19 +1,35 @@
-import type { PostGuardConfig, EncryptInput, UploadOptions, UploadResult } from './types.js';
+import type { PostGuardConfig, EncryptInput, SigningKeys, UploadOptions, UploadResult } from './types.js';
 import { sealRaw } from './crypto/encrypt.js';
 import { encryptPipeline } from './crypto/encrypt.js';
 import { createZipReadable } from './util/zip.js';
+import { resolveSigningKeys } from './crypto/signing.js';
 
 /** Lazy encryption builder. Nothing executes until a terminal method is called. */
 export class Sealed {
+  private cachedSigningKeys?: SigningKeys;
+
   /** @internal */
   constructor(
     private readonly config: PostGuardConfig,
     private readonly options: EncryptInput,
   ) {}
 
+  /** Resolve signing keys once and cache for subsequent calls. */
+  private async getSigningKeys(): Promise<SigningKeys> {
+    if (!this.cachedSigningKeys) {
+      this.cachedSigningKeys = await resolveSigningKeys(
+        this.config.pkgUrl,
+        this.options.sign,
+        this.config.headers,
+      );
+    }
+    return this.cachedSigningKeys;
+  }
+
   /** Encrypt and return raw bytes (buffers entire result in memory). */
   async toBytes(): Promise<Uint8Array> {
     const { recipients, sign } = this.options;
+    const signingKeys = await this.getSigningKeys();
 
     if (this.options.data) {
       // Raw data — seal directly, no ZIP
@@ -23,7 +39,7 @@ export class Sealed {
         recipients,
         data: this.options.data,
         headers: this.config.headers,
-        
+        signingKeys,
       });
     }
 
@@ -36,7 +52,7 @@ export class Sealed {
       recipients,
       data: zipReadable,
       headers: this.config.headers,
-      
+      signingKeys,
     });
   }
 
@@ -48,6 +64,7 @@ export class Sealed {
     }
 
     const { recipients, sign, onProgress, signal } = this.options;
+    const signingKeys = await this.getSigningKeys();
     const files = this.resolveFiles();
 
     return encryptPipeline({
@@ -60,7 +77,7 @@ export class Sealed {
       signal,
       delivery: opts?.notify,
       headers: this.config.headers,
-      
+      signingKeys,
     });
   }
 


### PR DESCRIPTION
## Summary
- `Sealed` now resolves signing keys once via `getSigningKeys()` and caches them
- `sealRaw` and `encryptPipeline` accept an optional `signingKeys` parameter to skip resolution when pre-resolved keys are provided
- Fixes the double QR code issue: when `createEnvelope` calls both `sealed.toBytes()` and `sealed.upload()` (for payloads > 100KB), each previously triggered a separate Yivi signing session

## Test plan
- [x] All 50 tests pass
- [ ] Verify only one QR code is shown when encrypting large emails