### PR TITLE
feat: configurable upload chunk size (default 5 MB)

### DIFF
--- a/src/crypto/chunker.ts
+++ b/src/crypto/chunker.ts
@@ -1,4 +1,4 @@
-const DEFAULT_CHUNK_SIZE = 1024 * 1024;
+const DEFAULT_CHUNK_SIZE = 5_000_000;
 
 export default class Chunker extends TransformStream<Uint8Array, Uint8Array> {
   constructor(chunkSize: number = DEFAULT_CHUNK_SIZE, offset?: number) {

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -8,7 +8,7 @@ import Chunker, { withTransform } from './chunker.js';
 import { createZipReadable } from '../util/zip.js';
 import { loadWasm } from '../util/wasm.js';
 
-const UPLOAD_CHUNK_SIZE = 1024 * 1024;
+const DEFAULT_UPLOAD_CHUNK_SIZE = 5_000_000;
 
 export interface EncryptPipelineOptions {
   pkgUrl: string;
@@ -18,6 +18,8 @@ export interface EncryptPipelineOptions {
   recipients: Recipient[];
   onProgress?: (percentage: number) => void;
   signal?: AbortSignal;
+  /** Size (in bytes) of each chunk sent during upload. Defaults to 5 000 000 (5 MB). */
+  uploadChunkSize?: number;
   delivery?: {
     message?: string;
     language?: 'EN' | 'NL';
@@ -88,7 +90,7 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
     },
   });
 
-  const uploadChunker = new Chunker(UPLOAD_CHUNK_SIZE);
+  const uploadChunker = new Chunker(options.uploadChunkSize ?? DEFAULT_UPLOAD_CHUNK_SIZE);
   const { writable, pipeDone } = withTransform(uploadStream.writable, uploadChunker, effectiveSignal);
 
   // Encrypt: ZIP -> sealStream -> chunker -> upload

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -75,6 +75,7 @@ export class Sealed {
       recipients,
       onProgress,
       signal,
+      uploadChunkSize: this.config.uploadChunkSize,
       delivery: opts?.notify,
       headers: this.config.headers,
       signingKeys,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export interface PostGuardConfig {
   pkgUrl: string;
   cryptifyUrl?: string;
   headers?: HeadersInit;
+  /** Size (in bytes) of each chunk sent during upload. Defaults to 5 000 000 (5 MB). */
+  uploadChunkSize?: number;
 }
 
 // --- Recipients ---


### PR DESCRIPTION
## Summary
- Add optional `uploadChunkSize` field to `PostGuardConfig` interface, allowing consumers to configure the upload chunk size per client instance.
- Change the default upload chunk size from 1 MB (1,048,576 bytes) to 5 MB (5,000,000 bytes) to better match the server-side chunk expectations.
- The setting flows from `PostGuardConfig` through `Sealed.upload()` into `encryptPipeline()` and ultimately to the `Chunker` transform stream.

## Test plan
- [ ] Verify `npm run build` passes (confirmed locally)
- [ ] Test upload with default chunk size (no `uploadChunkSize` set) — should use 5 MB chunks
- [ ] Test upload with custom `uploadChunkSize` in config — should use the provided value
- [ ] Test that `toBytes()` path (no upload) is unaffected