### PR TITLE
fix: observe both sealStream and pipeDone in encryptPipeline

### DIFF
--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -94,10 +94,48 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   const { writable, pipeDone } = withTransform(uploadStream.writable, uploadChunker, effectiveSignal);
 
   // Encrypt: ZIP -> sealStream -> chunker -> upload
-  await sealStream(mpk, sealOptions, readable, writable);
-  await pipeDone;
+  //
+  // sealStream and pipeDone are linked through the stream graph: when the
+  // upload writable errors (Cryptify CORS failure, network error, abort)
+  // the pipeTo rejects and that propagates back through the chunker so
+  // sealStream's writes start failing too. We must observe BOTH promises,
+  // otherwise the loser of the race surfaces as an unhandled rejection
+  // alongside the legitimate caller-facing error. We also explicitly
+  // abort the controller on the first failure so any in-flight fetch in
+  // createUploadStream / pipeTo tears down rather than dangling. */
+  await awaitAllOrAbort(
+    sealStream(mpk, sealOptions, readable, writable),
+    pipeDone,
+    abortController
+  );
 
   return { uuid: uploadStream.getUuid() };
+}
+
+/** Await two stream-pipeline promises, aborting on first failure and
+ *  re-throwing the first error. The losers' eventual rejections are
+ *  observed (`.catch(() => {})`) so they don't surface as unhandled. */
+async function awaitAllOrAbort(
+  seal: Promise<void>,
+  pipe: Promise<void>,
+  abortController: AbortController
+): Promise<void> {
+  let firstErr: unknown;
+  const observed = (p: Promise<void>): Promise<void> =>
+    p.catch((e) => {
+      if (firstErr === undefined) {
+        firstErr = e;
+        try {
+          abortController.abort(e);
+        } catch {
+          // Some environments throw if abort() is called with a reason
+          // they don't understand; fall back to a parameterless abort.
+          abortController.abort();
+        }
+      }
+    });
+  await Promise.all([observed(seal), observed(pipe)]);
+  if (firstErr !== undefined) throw firstErr;
 }
 
 export interface SealRawOptions {


### PR DESCRIPTION
## Summary

When Cryptify upload fails inside \`encryptPipeline\` (CORS preflight rejected, network error, abort), the underlying WritableStream errors. That propagates two ways through the stream graph:

1. \`pipeTo\` rejects because its destination is errored → \`pipeDone\` rejects.
2. The transform's writable side errors backwards → \`sealStream\`'s writes to it start failing → \`sealStream\` rejects.

Whichever rejected *second* was previously left as an unhandled promise rejection, because the code only awaited them sequentially:

\`\`\`ts
await sealStream(mpk, sealOptions, readable, writable);
await pipeDone;
\`\`\`

When \`sealStream\` lost the race the second \`await\` was never reached, so \`pipeDone\` surfaced as \`Uncaught (in promise) undefined\`. When \`pipeDone\` lost the race \`sealStream\`'s rejection had the same problem.

End-user symptom (and #32 trigger): an Office add-in or browser-tab consumer of \`createEnvelope\` falls back to the manual-upload link when Cryptify is unreachable — but the console fills with three stray stacks every send:

\`\`\`
Uncaught (in promise) TypeError: Failed to fetch
    at initUpload (...)
    ...
TypeError: Cannot enqueue a chunk into a closed readable stream
    at ZipTransformer.transform (...)
Uncaught (in promise) undefined
\`\`\`

## What this changes

Replaces the sequential awaits with a small \`awaitAllOrAbort\` helper that:

- Awaits both promises concurrently (each wrapped with \`.catch\` so the loser's eventual rejection is observed and not unhandled).
- Aborts the \`AbortController\` on first failure to tear down any in-flight \`fetch\` in \`createUploadStream\` and the \`pipeTo\`.
- Re-throws the first failure to the caller.

The visible-to-consumer behaviour is the same — \`sealed.upload()\` and \`createEnvelope\`'s existing catch still see the same single error — but the console no longer fills with stray stacks every time the upload path falls back.

## Test plan

- [x] \`npm run typecheck\` passes.
- [ ] CI: vitest suite (locally blocked — Node 19.1.0, vitest's rolldown needs ≥20).
- [ ] Manual: encrypt a tier-2 message with an unreachable Cryptify URL (\`cryptifyUrl: 'https://cryptify.invalid'\`). Expect \`createEnvelope\` to resolve with the manual-upload fallback link in the body, no \`Uncaught (in promise)\` errors in the console.
- [ ] Manual: encrypt a tier-2 message with a CORS-blocked Cryptify URL (e.g. cross-origin call to a server without \`Access-Control-Allow-Origin\` for our origin). Same expectation.
- [ ] Manual: happy path (Cryptify reachable, returns 200) still uploads and returns the UUID — no behaviour change for the success case.

## Closes

- Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)