### PR TITLE
fix: surface Yivi cancellation as YiviSessionError instead of bare string

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,3 +39,21 @@ export class IdentityMismatchError extends DecryptionError {
     this.name = 'IdentityMismatchError';
   }
 }
+
+/** Thrown when a Yivi session ends without a successful disclosure —
+ *  user dismissed the QR widget, declined disclosure in the Yivi app,
+ *  or the session timed out. The `reason` field carries the raw
+ *  yivi-core final-state string (`"Cancelled"`, `"TimedOut"`,
+ *  `"Aborted"`, …) for callers that want to distinguish. */
+export class YiviSessionError extends PostGuardError {
+  public readonly reason: string;
+  constructor(reason: string) {
+    super(`Yivi session ended without disclosure: ${reason}`);
+    this.name = 'YiviSessionError';
+    this.reason = reason;
+  }
+  /** Convenience: `reason === 'Cancelled'`. */
+  get cancelled(): boolean {
+    return this.reason === 'Cancelled';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export {
   PostGuardError,
   NetworkError,
   YiviNotInstalledError,
+  YiviSessionError,
   DecryptionError,
   IdentityMismatchError,
 } from './errors.js';

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -2,6 +2,7 @@ import { YiviCore } from '@privacybydesign/yivi-core';
 import { YiviClient } from '@privacybydesign/yivi-client';
 import { YiviWeb } from '@privacybydesign/yivi-web';
 import { injectYiviCss } from '../yivi/inject-css.js';
+import { YiviSessionError } from '../errors.js';
 import type { SigningKeys } from '../types.js';
 
 export interface YiviSignOptions {
@@ -121,10 +122,33 @@ export async function resolveSigningKeysFromYivi(
   yivi.use(YiviWeb);
   yivi.use(YiviClient);
 
-  const result = await yivi.start() as any;
+  // yivi-core's start() rejects with a bare string final-state name on
+  // anything other than Success ("Cancelled", "TimedOut", "Aborted").
+  // Translate that into a proper Error so consumers' try/catch +
+  // instanceof checks work, and so the rejection has a useful stack and
+  // message instead of a one-word primitive. Also clear the widget host
+  // element so the cancelled/red-X UI doesn't linger past the rejection.
+  let result: any;
+  try {
+    result = await yivi.start();
+  } catch (raw) {
+    cleanupYiviHost(opts.element);
+    if (raw instanceof Error) throw raw;
+    if (typeof raw === 'string') throw new YiviSessionError(raw);
+    throw new YiviSessionError(String(raw ?? 'Unknown'));
+  }
   return {
     pubSignKey: result.pubSignKey,
     privSignKey: result.privSignKey,
     senderEmail: senderEmail ?? opts.senderEmail,
   };
+}
+
+function cleanupYiviHost(selector: string): void {
+  try {
+    const host = typeof document !== 'undefined' ? document.querySelector(selector) : null;
+    if (host) host.innerHTML = '';
+  } catch {
+    // ignore — non-DOM environments or detached selectors
+  }
 }

--- a/src/yivi/decrypt-session.ts
+++ b/src/yivi/decrypt-session.ts
@@ -1,7 +1,7 @@
 import { YiviCore } from '@privacybydesign/yivi-core';
 import { YiviClient } from '@privacybydesign/yivi-client';
 import { YiviWeb } from '@privacybydesign/yivi-web';
-import { PostGuardError } from '../errors.js';
+import { PostGuardError, YiviSessionError } from '../errors.js';
 import { injectYiviCss } from './inject-css.js';
 
 // Re-export utilities from shared module
@@ -156,5 +156,26 @@ export async function retrieveUSKViaYivi(
   yivi.use(YiviWeb);
   yivi.use(YiviClient);
 
-  return yivi.start();
+  // yivi-core's start() rejects with a bare string final-state name on
+  // anything other than Success ("Cancelled", "TimedOut", "Aborted").
+  // Translate to a proper Error so consumer try/catch + instanceof
+  // checks behave, and clear the widget host so the cancelled red-X UI
+  // doesn't linger past the rejection.
+  try {
+    return await yivi.start();
+  } catch (raw) {
+    cleanupYiviHost(element);
+    if (raw instanceof Error) throw raw;
+    if (typeof raw === 'string') throw new YiviSessionError(raw);
+    throw new YiviSessionError(String(raw ?? 'Unknown'));
+  }
+}
+
+function cleanupYiviHost(selector: string): void {
+  try {
+    const host = typeof document !== 'undefined' ? document.querySelector(selector) : null;
+    if (host) host.innerHTML = '';
+  } catch {
+    // ignore — non-DOM environments or detached selectors
+  }
 }


### PR DESCRIPTION
## Summary

yivi-core's \`start()\` rejects with a primitive *string* final-state name (\`\"Cancelled\"\`, \`\"TimedOut\"\`, \`\"Aborted\"\`, …) on anything other than Success. Source (yivi-core/dist/index.mjs):

\`\`\`js
isFinal -> _close(returnValue).then(
  newState === 'Success' ? this._resolve : this._reject)
\`\`\`

That breaks the usual \`err instanceof Error\` / \`err.message\` shape consumers expect. In addon code wrapping \`pg.encrypt\` / \`pg.opened.decrypt\` in try/catch, the cancel branch surfaces as a generic \"Encryption failed. Please try again.\" because the catch block can't tell what went wrong, and consumers can't distinguish cancellation from real errors.

## What this changes

Two yivi.start() call sites in pg-js:

- \`src/signing/yivi.ts\` — encrypt / sign flow
- \`src/yivi/decrypt-session.ts\` — open / decrypt flow

Both are now wrapped in try/catch that:

1. Lets real \`Error\` instances pass through unchanged.
2. Translates a primitive string rejection into a new \`YiviSessionError(reason)\` carrying the raw state name. \`.cancelled\` is a getter for the common \`reason === 'Cancelled'\` case.
3. Clears the widget host element so yivi-web's stale \"Cancelled\" panel doesn't linger after the rejection.

\`YiviSessionError\` is exported from the package root.

## Consumer pattern after this

\`\`\`ts
import { YiviSessionError } from '@e4a/pg-js';

try {
  await pg.encrypt({ sign: pg.sign.yivi(...), ... });
} catch (e) {
  if (e instanceof YiviSessionError && e.cancelled) {
    showRetryUi();          // user clicked Cancel in the Yivi app
  } else if (e instanceof YiviSessionError) {
    showError(e.message);   // timeout, abort, etc.
  } else {
    showError(String(e));
  }
}
\`\`\`

## Test plan

- [x] \`npm run typecheck\` passes.
- [ ] CI: vitest suite (locally blocked — Node 19.1.0, vitest's rolldown needs ≥20).
- [ ] Manual encrypt: scan QR, decline disclosure in Yivi app. Expect \`pg.encrypt\` to reject with \`YiviSessionError\` where \`reason === 'Cancelled'\`. The widget's red-X panel is cleared.
- [ ] Manual decrypt: same flow on the open/decrypt side via \`pg.open({ uuid }).decrypt(...)\`.
- [ ] Smoke: existing happy paths continue to resolve as before.

## Closes

- Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)