### PR TITLE
feat(envelope): use hosted checkmark.png in Sent by section

### DIFF
--- a/src/email/envelope.ts
+++ b/src/email/envelope.ts
@@ -43,6 +43,7 @@ export async function createEnvelope(options: CreateEnvelopeOptions): Promise<En
   const messageSection = unencryptedMessage
     ? buildUnencryptedSection(unencryptedMessage)
     : '';
+  const checkmarkUrl = `${websiteUrl}/checkmark.png`;
 
   const htmlBody = `<!DOCTYPE html>
 <html lang="en">
@@ -73,7 +74,7 @@ export async function createEnvelope(options: CreateEnvelopeOptions): Promise<En
                 </div>
                 <div style="margin-top:40px;padding-top:30px;border-top:1px solid #C6E2F6;text-align:center;">
                     <p style="font-size:13px;color:#5F7381;margin:0 0 6px 0;">Sent by</p>
-                    <p style="font-size:15px;font-weight:700;color:#030E17;margin:0 0 12px 0;">${escapeHtml(from)}</p>${buildAttributePills(senderAttributes)}
+                    <p style="font-size:15px;font-weight:700;color:#030E17;margin:0 0 12px 0;"><img src="${checkmarkUrl}" alt="" width="14" height="12" style="vertical-align:middle;margin-right:6px;display:inline-block;" />${escapeHtml(from)}</p>${buildAttributePills(senderAttributes)}
                 </div>
             </div>
             <div style="height:40px;"></div>


### PR DESCRIPTION
## Summary

Closes #19. The encrypted-email envelope now renders a small \"verified sender\" checkmark image next to the sender email, served from \`\${websiteUrl}/checkmark.png\` — same hosting strategy as \`pg_logo.png\`.

## Source

The checkmark is the same path used by postguard-website's \`/download\` page success-banner / \`verifiedEmail\` section (\`viewBox=\"0 0 12 10\"\`, stroke \`#5F7381\`). Companion PR adds the PNG to postguard-website's static dir: encryption4all/postguard-website#129.

## Why an \`<img>\` instead of inline SVG / Unicode

- Mail clients render inline \`<svg>\` inconsistently (Gmail strips it; Outlook desktop falls back to a placeholder).
- A Unicode glyph styled with CSS depends on the recipient's font stack and theme.
- Hosted PNG matches what we already do for \`pg_logo.png\` and renders identically everywhere.

## Markup

\`\`\`html
<p style=\"...\">
  <img src=\"\${websiteUrl}/checkmark.png\" alt=\"\" width=\"14\" height=\"12\" style=\"vertical-align:middle;margin-right:6px;display:inline-block;\" />
  \${escapeHtml(from)}
</p>
\`\`\`

\`14×12\` matches the SVG's natural 12:10 aspect (no distortion). \`alt=\"\"\` keeps screen readers from announcing it (the \`Sent by\` label already provides context).

## Test plan

- [x] \`npm run typecheck\` passes.
- [ ] CI: vitest suite (locally blocked — Node 19.1.0, vitest's rolldown needs ≥20).
- [ ] Manual: encrypt a message, view the envelope HTML in a browser. Expect a small grey-blue checkmark immediately to the left of the sender email in the \"Sent by\" footer.
- [ ] Manual: same in a mail client (Gmail web, Outlook web, Thunderbird) — image loads and aligns with the email text.

## Closes

- Closes #19

## Sequencing note

Won't render correctly until postguard-website#129 is merged and \`https://postguard.eu/checkmark.png\` is live. Until then the email will show a broken-image icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)