### PR TITLE
feat(upload): silent-by-default, opt-in notify.recipients / notify.sender

### DIFF
--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -9,7 +9,16 @@ export interface InitUploadOptions {
   recipient: string;
   mailContent?: string;
   mailLang?: 'EN' | 'NL';
+  /** Send a confirmation email to the sender. Default false. Maps to
+   *  the wire-level `confirm` field. */
   confirm?: boolean;
+  /** Send a notification email to each recipient. Default false in the
+   *  SDK (overrides Cryptify's server-side default of true for clients
+   *  that don't send the field, so callers get a silent upload by
+   *  default). Requires cryptify ≥ the release that added the
+   *  `notifyRecipients` field; older servers ignore it and continue to
+   *  email recipients. */
+  notifyRecipients?: boolean;
   signal?: AbortSignal;
 }
 
@@ -27,6 +36,10 @@ export async function initUpload(
       recipient: options.recipient,
       mailContent: options.mailContent ?? '',
       mailLang: options.mailLang ?? 'EN',
+      // Always send the field so older Cryptify deployments (default
+      // notifyRecipients: true) get explicitly overridden to the SDK's
+      // silent-by-default semantics.
+      notifyRecipients: options.notifyRecipients ?? false,
     }),
   });
 

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -21,9 +21,12 @@ export interface EncryptPipelineOptions {
   /** Size (in bytes) of each chunk sent during upload. Defaults to 5 000 000 (5 MB). */
   uploadChunkSize?: number;
   delivery?: {
+    /** Send a notification email to each recipient. Default false. */
+    recipients?: boolean;
+    /** Send a confirmation email to the sender. Default false. */
+    sender?: boolean;
     message?: string;
     language?: 'EN' | 'NL';
-    confirmToSender?: boolean;
   };
   headers?: HeadersInit;
   /** Pre-resolved signing keys (skips Yivi/API key resolution if provided) */
@@ -80,7 +83,8 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
     recipient: recipientEmails,
     mailContent: delivery?.message,
     mailLang: delivery?.language,
-    confirm: delivery?.confirmToSender,
+    confirm: delivery?.sender,
+    notifyRecipients: delivery?.recipients,
     abortSignal: effectiveSignal,
     onProgress: (uploaded, last) => {
       if (onProgress) {

--- a/src/email/envelope.ts
+++ b/src/email/envelope.ts
@@ -33,7 +33,7 @@ const DEFAULT_WEBSITE_URL = 'https://postguard.eu';
  *  Outlook's 1 M-char setAsync limit and was redundant with the
  *  attachment / fragment link. */
 export async function createEnvelope(options: CreateEnvelopeOptions): Promise<EnvelopeResult> {
-  const { sealed, from, unencryptedMessage, senderAttributes } = options;
+  const { sealed, from, unencryptedMessage, senderAttributes, notify } = options;
   const websiteUrl = options.websiteUrl ?? DEFAULT_WEBSITE_URL;
   const uploadToCryptify = options.uploadToCryptify ?? true;
   const logoUrl = `${websiteUrl}/pg_logo.png`;
@@ -59,7 +59,7 @@ export async function createEnvelope(options: CreateEnvelopeOptions): Promise<En
 
     if (tryUpload) {
       try {
-        const result = await sealed.upload();
+        const result = await sealed.upload(notify ? { notify } : undefined);
         uploadUuid = result.uuid;
       } catch {
         // Network / CORS / Cryptify-unavailable. Fall through to

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -71,7 +71,11 @@ export class Sealed {
   }
 
   /** Encrypt and upload to Cryptify (streams internally for efficiency).
-   *  Pass `notify` to have Cryptify send email notifications to recipients. */
+   *  Silent by default — pass `notify.recipients = true` to have
+   *  Cryptify email each recipient a download link, and/or
+   *  `notify.sender = true` for a confirmation back to the sender.
+   *  `notify.message` adds an optional unencrypted body shared by both
+   *  mails. */
   async upload(opts?: UploadOptions): Promise<UploadResult> {
     if (!this.config.cryptifyUrl) {
       throw new Error('cryptifyUrl is required for upload');

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,11 +76,25 @@ export interface EncryptInput {
 
 /** Options for sealed.upload() */
 export interface UploadOptions {
-  /** If provided, Cryptify sends email notifications to recipients */
+  /** Cryptify notification settings. Both recipient and sender mails
+   *  are opt-in: omit `notify` (or omit the `recipients` / `sender`
+   *  fields) and the upload is silent. Use this when the encrypted
+   *  payload is being delivered through another channel (e.g. an email
+   *  client) — pass an explicit toggle when Cryptify itself should
+   *  email anyone. */
   notify?: {
+    /** Send a notification email to each recipient with a download
+     *  link. Default false. */
+    recipients?: boolean;
+    /** Send a confirmation email back to the sender. Default false.
+     *  Independent of `recipients`. */
+    sender?: boolean;
+    /** Optional unencrypted message body included in any notification
+     *  email(s) sent — both the per-recipient mail and the sender
+     *  confirmation, when those are enabled. */
     message?: string;
+    /** Notification email template language. Default 'EN'. */
     language?: 'EN' | 'NL';
-    confirmToSender?: boolean;
   };
 }
 
@@ -208,6 +222,12 @@ export interface CreateEnvelopeOptions {
    *  Tier 2; Tier 3 (over `PG_MAX_ATTACHMENT_SIZE`) always uploads because
    *  there is no attachment fallback. */
   uploadToCryptify?: boolean;
+  /** Notification settings for the underlying Cryptify upload. Same
+   *  shape as `Sealed.upload`'s `notify`. Silent by default — set
+   *  `notify.recipients = true` to opt into per-recipient mails, etc.
+   *  Has no effect on Tier 1 (no upload happens) or when
+   *  `uploadToCryptify: false` already skipped the upload. */
+  notify?: UploadOptions['notify'];
 }
 
 /** Which tier the envelope falls into based on encrypted payload size.


### PR DESCRIPTION
Closes #40.

## Why

`sealed.upload` triggered Cryptify's per-recipient notification email unconditionally; the existing `notify` block only customized mail *content*. The docstring even claimed \"Pass `notify` to have Cryptify send email notifications to recipients\" — the opposite of reality.

That made the upload pipeline unsuitable for any consumer delivering the encrypted payload through another channel (e.g. the Outlook add-on, which sends the encrypted message from the user's own mailbox) — the Cryptify mail then arrived as a duplicate.

## API redesign

Per upstream guidance there are no production consumers of `@e4a/pg-js` yet, so this PR ships the clean shape rather than aliasing the old one.

```ts
sealed.upload({
  notify: {
    recipients: true,           // ← opt-in (default false) — new
    sender: true,               // ← opt-in (default false) — was confirmToSender
    message: 'See you tomorrow.',
    language: 'EN',
  },
});
```

| field | default | effect |
| --- | --- | --- |
| `recipients` | `false` | per-recipient notification email |
| `sender` | `false` | sender confirmation email |
| `message` | `''` | unencrypted text on any mails sent |
| `language` | `'EN'` | template language |

Symmetric and silent-by-default: `sealed.upload()` (no `notify`) sends no mails at all. Same shape exposed on `pg.email.createEnvelope`'s `notify` option for tier 2/3 envelopes.

## Wire compatibility

The SDK now always sends `notifyRecipients` (defaulting to `false` when omitted) on the wire. That matters because Cryptify deployments older than encryption4all/cryptify#135 default `notifyRecipients` to `true` server-side — by sending an explicit `false`, the SDK keeps its silent-by-default semantics regardless of which Cryptify version it's hitting.

`notify.sender` maps to the existing wire-level `confirm` field (no rename on the wire — keeps any direct curl callers of cryptify working).

## Breaking changes

- `notify.confirmToSender` → `notify.sender` (renamed).
- `sealed.upload({ notify: {} })` (or `sealed.upload()`) is now silent. Previously this still triggered recipient mail because the cryptify default fired. Callers who *want* the old default need `notify: { recipients: true }`.

## Coordination

- **encryption4all/cryptify#135** — adds the matching `notifyRecipients` wire field on the server.
- **encryption4all/postguard-dotnet** PR — same redesign for the .NET SDK.
- Downstream of this PR: the website fileshare (`SendButton.svelte`) and the sveltekit example call `sealed.upload({ notify: { confirmToSender: true } })` and rely on the implicit recipient-mail default. Those need a one-line update to `notify: { recipients: true, sender: true }`. Happy to file follow-up PRs to those repos once this lands.

## Test plan

- [ ] `sealed.upload()` against an updated cryptify → no mails sent. `result.uuid` valid.
- [ ] `sealed.upload({ notify: { recipients: true } })` → recipient mail; no sender mail.
- [ ] `sealed.upload({ notify: { sender: true } })` → sender confirmation only.
- [ ] `sealed.upload({ notify: { recipients: true, sender: true, message: 'hi' } })` → both mails carry the unencrypted message body.
- [ ] `pg.email.createEnvelope({ ..., notify: { recipients: false } })` for a tier-3 payload → upload completes (must, no attachment fallback) but no recipient mail.
- [ ] Against a *pre-update* cryptify, `sealed.upload()` → still no recipient mail (the SDK's explicit `notifyRecipients: false` overrides cryptify's server default).
- [ ] `tsc --noEmit` clean.