### PR TITLE
feat(cryptify): forward API key to Cryptify uploads as Bearer auth

### DIFF
--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -19,7 +19,17 @@ export interface InitUploadOptions {
    *  `notifyRecipients` field; older servers ignore it and continue to
    *  email recipients. */
   notifyRecipients?: boolean;
+  /** PostGuard for Business API key (`PG-…`). When set, sent to Cryptify
+   *  as `Authorization: Bearer <apiKey>` on every upload request. Cryptify
+   *  forwards the bearer to PKG's `/v2/api-key/validate`; a validated key
+   *  unlocks the higher upload-quota tier (100 GB/upload + 100 GB rolling
+   *  vs. the default 5 GB caps). */
+  apiKey?: string;
   signal?: AbortSignal;
+}
+
+function bearerHeader(apiKey?: string): Record<string, string> {
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
 }
 
 /** Initialize a file upload, returns token and uuid */
@@ -30,7 +40,10 @@ export async function initUpload(
   const response = await fetch(`${cryptifyUrl}/fileupload/init`, {
     signal: options.signal,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...bearerHeader(options.apiKey),
+    },
     body: JSON.stringify({
       confirm: options.confirm ?? false,
       recipient: options.recipient,
@@ -59,7 +72,8 @@ export async function storeChunk(
   state: FileState,
   chunk: Uint8Array,
   offset: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  apiKey?: string
 ): Promise<FileState> {
   const response = await fetch(`${cryptifyUrl}/fileupload/${state.uuid}`, {
     signal,
@@ -68,6 +82,7 @@ export async function storeChunk(
       cryptifytoken: state.token,
       'Content-Type': 'application/octet-stream',
       'content-range': `bytes ${offset}-${offset + chunk.length}/*`,
+      ...bearerHeader(apiKey),
     },
     body: new Blob([chunk as BlobPart]),
   });
@@ -86,7 +101,8 @@ export async function finalizeUpload(
   cryptifyUrl: string,
   state: FileState,
   size: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  apiKey?: string
 ): Promise<void> {
   const response = await fetch(`${cryptifyUrl}/fileupload/finalize/${state.uuid}`, {
     signal,
@@ -94,6 +110,7 @@ export async function finalizeUpload(
     headers: {
       cryptifytoken: state.token,
       'content-range': `bytes */${size}`,
+      ...bearerHeader(apiKey),
     },
   });
 
@@ -155,7 +172,7 @@ export function createUploadStream(
       },
       async write(chunk, c) {
         try {
-          state = await storeChunk(cryptifyUrl, state, chunk, processed, signal);
+          state = await storeChunk(cryptifyUrl, state, chunk, processed, signal, options.apiKey);
           processed += chunk.length;
           onProgress?.(processed, false);
           if (signal?.aborted) throw new Error('Abort signaled during storeChunk.');
@@ -169,7 +186,7 @@ export function createUploadStream(
         const combinedSignal = signal
           ? AbortSignal.any([signal, controller.signal])
           : controller.signal;
-        await finalizeUpload(cryptifyUrl, state, processed, combinedSignal);
+        await finalizeUpload(cryptifyUrl, state, processed, combinedSignal, options.apiKey);
         onProgress?.(processed, true);
         clearTimeout(timeoutId);
         if (signal?.aborted) throw new Error('Abort signaled during finalize.');

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -79,12 +79,19 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   const recipientEmails = recipients.map((r) => r.email).join(', ');
   const totalSize = files.reduce((a, f) => a + f.size, 0);
 
+  // Forward the business API key (when signing via apiKey) to Cryptify so
+  // the upload runs under the higher quota tier. Cryptify validates the
+  // bearer against PKG; an unrecognised or missing key falls back to the
+  // default 5 GB caps.
+  const cryptifyApiKey = sign.type === 'apiKey' ? sign.apiKey : undefined;
+
   const uploadStream = createUploadStream(cryptifyUrl, {
     recipient: recipientEmails,
     mailContent: delivery?.message,
     mailLang: delivery?.language,
     confirm: delivery?.sender,
     notifyRecipients: delivery?.recipients,
+    apiKey: cryptifyApiKey,
     abortSignal: effectiveSignal,
     onProgress: (uploaded, last) => {
       if (onProgress) {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -109,6 +109,51 @@ describe('Cryptify API', () => {
         initUpload('https://cryptify.example.com', { recipient: 'a@b.com' })
       ).rejects.toThrow(NetworkError);
     });
+
+    it('omits Authorization header when no apiKey is set', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ uuid: 'u' }),
+        text: () => Promise.resolve(''),
+        headers: new Headers({ cryptifytoken: 't' }),
+      });
+
+      await initUpload('https://cryptify.example.com', { recipient: 'a@b.com' });
+
+      // Without an apiKey, the Authorization key must not appear at all in
+      // the outgoing init — using `not.objectContaining` rather than
+      // checking for `undefined` so we don't depend on whether the spread
+      // produced an explicit `undefined` value vs. an absent key.
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cryptify.example.com/fileupload/init',
+        expect.objectContaining({
+          headers: expect.not.objectContaining({ Authorization: expect.anything() }),
+        })
+      );
+    });
+
+    it('sends Authorization: Bearer <apiKey> when apiKey is set', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ uuid: 'u' }),
+        text: () => Promise.resolve(''),
+        headers: new Headers({ cryptifytoken: 't' }),
+      });
+
+      await initUpload('https://cryptify.example.com', {
+        recipient: 'a@b.com',
+        apiKey: 'PG-test-key',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cryptify.example.com/fileupload/init',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer PG-test-key' }),
+        })
+      );
+    });
   });
 
   describe('storeChunk', () => {
@@ -136,6 +181,30 @@ describe('Cryptify API', () => {
           headers: expect.objectContaining({
             'content-range': 'bytes 0-4/*',
           }),
+        })
+      );
+    });
+
+    it('forwards Authorization: Bearer <apiKey> when set', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ cryptifytoken: 'tok' }),
+      });
+
+      await storeChunk(
+        'https://cryptify.example.com',
+        { token: 't', uuid: 'u' },
+        new Uint8Array([1]),
+        0,
+        undefined,
+        'PG-test-key'
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cryptify.example.com/fileupload/u',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer PG-test-key' }),
         })
       );
     });
@@ -171,6 +240,46 @@ describe('Cryptify API', () => {
           100
         )
       ).rejects.toThrow(NetworkError);
+    });
+
+    it('forwards Authorization: Bearer <apiKey> when set', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') });
+
+      await finalizeUpload(
+        'https://cryptify.example.com',
+        { token: 't', uuid: 'u' },
+        100,
+        undefined,
+        'PG-test-key'
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cryptify.example.com/fileupload/finalize/u',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer PG-test-key' }),
+        })
+      );
+    });
+
+    it('surfaces 503 from cryptify as NetworkError when pkg is unreachable', async () => {
+      // When cryptify cannot validate the API key against pkg AND the
+      // upload exceeds the default tier, cryptify returns 503. The SDK
+      // surfaces this as a NetworkError with status 503 so callers can
+      // distinguish it from quota / auth errors.
+      mockFetch.mockResolvedValueOnce(errorResponse(503, 'pg-pkg unreachable'));
+
+      await expect(
+        finalizeUpload(
+          'https://cryptify.example.com',
+          { token: 't', uuid: 'u' },
+          200_000_000_000,
+          undefined,
+          'PG-test-key'
+        )
+      ).rejects.toMatchObject({
+        name: 'NetworkError',
+        status: 503,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Pairs with encryption4all/cryptify#139 (and encryption4all/postguard#167). Cryptify is moving its quota-tier check from \"any \`X-Api-Key\` header present\" to \"\`Authorization: Bearer PG-…\` validated against PKG.\" SDK callers using \`pg.sign.apiKey(...)\` need the same key on the upload itself to keep getting the higher tier — this PR threads it through automatically.

## What changed

- `InitUploadOptions` gains `apiKey?: string`.
- `initUpload`, `storeChunk`, `finalizeUpload` attach `Authorization: Bearer <apiKey>` when set.
- `createUploadStream` reads `apiKey` from options and forwards it on every chunk + finalize.
- `encryptPipeline` extracts the key from `sign` when `sign.type === 'apiKey'` and passes it down. Yivi / session signing flows are untouched.

No public API change for callers using \`sealed.upload()\` / \`pg.encrypt()\` — the existing \`pg.sign.apiKey('PG-…')\` flow now Just Works against the new Cryptify behaviour.

## Failure modes (driven by Cryptify)

| Cryptify-side state | SDK-side outcome |
|---|---|
| Key validates against PKG | Higher tier (100 GB / 100 GB rolling) |
| Key missing / unknown / expired | Silent degrade to default tier (5 GB) |
| PKG unreachable, upload ≤ 5 GB | Default tier with a server-side warning logged |
| PKG unreachable, upload > 5 GB | Cryptify returns 503 → SDK throws \`NetworkError { status: 503 }\` |

## Tests

5 new cases in \`tests/api.test.ts\`:
- \`initUpload\` omits Authorization when no \`apiKey\`
- \`initUpload\` sends \`Bearer PG-…\` when \`apiKey\` is set
- \`storeChunk\` forwards the key on each chunk PUT
- \`finalizeUpload\` forwards the key on the final POST
- 503 from cryptify surfaces as \`NetworkError\` with \`status: 503\`

Full suite: \`npm test\` → **55 passed; 0 failed**. \`tsc --noEmit\` clean.

## Deploy order

1. encryption4all/postguard#167 (pg-pkg \`/v2/api-key/validate\`)
2. encryption4all/cryptify#139 (cryptify reads the bearer)
3. This PR (SDK forwards the bearer)

Reversing 2 and 3 is fine — older Cryptify ignores the header. Reversing 1 and 2 means cryptify's API-key uploads burn the 30 s retry budget and 503 if over-default.

## Test plan

- [ ] CI green
- [ ] Smoke against staging once the cryptify side is deployed:
  - [ ] \`pg.encrypt({ sign: pg.sign.apiKey('PG-real-key'), files: [...] }).upload()\` for a >5 GB payload — should succeed (proves the bearer reaches cryptify)
  - [ ] Same with a bogus key — should 413 at >5 GB (silent degrade to default tier)
  - [ ] Same with a valid key + cryptify config pointing at a stopped PKG — small upload succeeds, large upload throws \`NetworkError\` with \`status: 503\`