### PR TITLE
feat(upload): retry chunks and downloads with exponential backoff

### DIFF
--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -1,7 +1,23 @@
-import { NetworkError } from '../errors.js';
+import { NetworkError, UploadSessionExpiredError } from '../errors.js';
+import {
+  resolveRetryOptions,
+  withRetry,
+  withTimeout,
+  type ResolvedRetryOptions,
+  type RetryOptions,
+} from '../util/retry.js';
 
 interface FileState {
+  /** Current rolling token — what the next chunk PUT should send. */
   token: string;
+  /**
+   * Token sent on the most recent chunk PUT (i.e., the value of `token`
+   * before that PUT advanced it). On a retry whose response was lost,
+   * the caller resends with this value so cryptify's idempotent-retry
+   * path replays the cached response. `undefined` until at least one
+   * chunk has been committed.
+   */
+  prevToken?: string;
   uuid: string;
 }
 
@@ -30,6 +46,30 @@ export interface InitUploadOptions {
 
 function bearerHeader(apiKey?: string): Record<string, string> {
   return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
+/** Cryptify's `upload_session_not_found` error code in the structured 404 body. */
+const UPLOAD_SESSION_NOT_FOUND_ERROR = 'upload_session_not_found';
+
+/**
+ * Inspect a 404 response body. If it's the structured
+ * `upload_session_not_found` JSON cryptify started returning, throw the
+ * dedicated error so retry policies can short-circuit. Otherwise fall
+ * through to a plain NetworkError.
+ */
+function throwSessionExpiredOrNetworkError(message: string, status: number, body: string, uuid: string): never {
+  if (status === 404) {
+    try {
+      const parsed = JSON.parse(body) as { error?: string; reason?: string; uuid?: string };
+      if (parsed.error === UPLOAD_SESSION_NOT_FOUND_ERROR) {
+        throw new UploadSessionExpiredError(parsed.uuid ?? uuid, parsed.reason ?? 'unknown', body);
+      }
+    } catch (e) {
+      if (e instanceof UploadSessionExpiredError) throw e;
+      // JSON parse failure or other — fall through to NetworkError below.
+    }
+  }
+  throw new NetworkError(message, status, body);
 }
 
 /** Initialize a file upload, returns token and uuid */
@@ -66,7 +106,15 @@ export async function initUpload(
   return { token, uuid: resJson['uuid'] };
 }
 
-/** Upload a single chunk */
+/**
+ * Upload a single chunk.
+ *
+ * On retry callers should pass the *previous* token (in `prevToken`) so
+ * that cryptify's idempotent-retry path can recognise a duplicate of the
+ * just-committed chunk. The first attempt sends `state.token`; subsequent
+ * attempts send `state.prevToken ?? state.token` to cover the case where
+ * the previous response was lost in flight.
+ */
 export async function storeChunk(
   cryptifyUrl: string,
   state: FileState,
@@ -89,11 +137,44 @@ export async function storeChunk(
 
   if (!response.ok) {
     const body = await response.text();
-    throw new NetworkError(`Error uploading chunk`, response.status, body);
+    throwSessionExpiredOrNetworkError(`Error uploading chunk`, response.status, body, state.uuid);
   }
 
   const token = response.headers.get('cryptifytoken') as string;
-  return { token, uuid: state.uuid };
+  return { token, uuid: state.uuid, prevToken: state.token };
+}
+
+/**
+ * Upload a chunk with retry on transient failures. On retry the *previous*
+ * token is sent so cryptify can detect this as a duplicate of the
+ * just-committed chunk and replay the cached response without re-writing
+ * or double-counting against quotas. See cryptify's idempotent-retry
+ * contract on `PUT /fileupload/{uuid}`.
+ */
+export async function storeChunkWithRetry(
+  cryptifyUrl: string,
+  state: FileState,
+  chunk: Uint8Array,
+  offset: number,
+  retry: ResolvedRetryOptions,
+  signal?: AbortSignal,
+  apiKey?: string
+): Promise<FileState> {
+  return withRetry(
+    async (attempt) => {
+      const tokenForThisAttempt = attempt === 1 ? state.token : (state.prevToken ?? state.token);
+      const stateForAttempt: FileState = { ...state, token: tokenForThisAttempt };
+      const { signal: timed, cleanup } = withTimeout(signal, retry.chunkTimeoutMs);
+      try {
+        return await storeChunk(cryptifyUrl, stateForAttempt, chunk, offset, timed, apiKey);
+      } finally {
+        cleanup();
+      }
+    },
+    retry,
+    undefined,
+    signal
+  );
 }
 
 /** Finalize the upload */
@@ -116,7 +197,7 @@ export async function finalizeUpload(
 
   if (!response.ok) {
     const body = await response.text();
-    throw new NetworkError(`Error finalizing upload`, response.status, body);
+    throwSessionExpiredOrNetworkError(`Error finalizing upload`, response.status, body, state.uuid);
   }
 }
 
@@ -140,6 +221,38 @@ export async function downloadFile(
   return response.body as ReadableStream<Uint8Array>;
 }
 
+/**
+ * Download with retry on transient failures. Cryptify's `FileServer`
+ * already supports HTTP Range requests, so this could be extended to
+ * resume mid-stream — that's tracked separately. Today the retry simply
+ * re-issues the GET on transient failure.
+ */
+export async function downloadFileWithRetry(
+  cryptifyUrl: string,
+  uuid: string,
+  retry: ResolvedRetryOptions,
+  signal?: AbortSignal
+): Promise<ReadableStream<Uint8Array>> {
+  return withRetry(
+    async () => {
+      const { signal: timed, cleanup } = withTimeout(signal, retry.downloadTimeoutMs);
+      try {
+        return await downloadFile(cryptifyUrl, uuid, timed);
+      } finally {
+        // Note: downloadFile returns a stream that is read *after* this
+        // function returns, so a per-attempt timeout that aborts the
+        // stream mid-read would surface as a stream error. We only
+        // bound the GET handshake here; if downloadTimeoutMs is 0 (the
+        // default) cleanup is a no-op.
+        cleanup();
+      }
+    },
+    retry,
+    undefined,
+    signal
+  );
+}
+
 export interface UploadStream {
   writable: WritableStream<Uint8Array>;
   getUuid: () => string;
@@ -151,12 +264,14 @@ export function createUploadStream(
   options: InitUploadOptions & {
     onProgress?: (uploaded: number, last: boolean) => void;
     abortSignal?: AbortSignal;
+    retry?: RetryOptions;
   }
 ): UploadStream {
   let state: FileState = { token: '', uuid: '' };
   let processed = 0;
   const signal = options.abortSignal;
   const onProgress = options.onProgress;
+  const retry = resolveRetryOptions(options.retry);
   const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 
   const writable = new WritableStream<Uint8Array>(
@@ -172,7 +287,15 @@ export function createUploadStream(
       },
       async write(chunk, c) {
         try {
-          state = await storeChunk(cryptifyUrl, state, chunk, processed, signal, options.apiKey);
+          state = await storeChunkWithRetry(
+            cryptifyUrl,
+            state,
+            chunk,
+            processed,
+            retry,
+            signal,
+            options.apiKey
+          );
           processed += chunk.length;
           onProgress?.(processed, false);
           if (signal?.aborted) throw new Error('Abort signaled during storeChunk.');
@@ -181,14 +304,13 @@ export function createUploadStream(
         }
       },
       async close() {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 60000);
-        const combinedSignal = signal
-          ? AbortSignal.any([signal, controller.signal])
-          : controller.signal;
-        await finalizeUpload(cryptifyUrl, state, processed, combinedSignal, options.apiKey);
+        const { signal: timed, cleanup } = withTimeout(signal, retry.finalizeTimeoutMs);
+        try {
+          await finalizeUpload(cryptifyUrl, state, processed, timed, options.apiKey);
+        } finally {
+          cleanup();
+        }
         onProgress?.(processed, true);
-        clearTimeout(timeoutId);
         if (signal?.aborted) throw new Error('Abort signaled during finalize.');
       },
       async abort() {

--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -59,14 +59,14 @@ const UPLOAD_SESSION_NOT_FOUND_ERROR = 'upload_session_not_found';
  */
 function throwSessionExpiredOrNetworkError(message: string, status: number, body: string, uuid: string): never {
   if (status === 404) {
+    let parsed: { error?: string; reason?: string; uuid?: string } | undefined;
     try {
-      const parsed = JSON.parse(body) as { error?: string; reason?: string; uuid?: string };
-      if (parsed.error === UPLOAD_SESSION_NOT_FOUND_ERROR) {
-        throw new UploadSessionExpiredError(parsed.uuid ?? uuid, parsed.reason ?? 'unknown', body);
-      }
-    } catch (e) {
-      if (e instanceof UploadSessionExpiredError) throw e;
-      // JSON parse failure or other — fall through to NetworkError below.
+      parsed = JSON.parse(body);
+    } catch {
+      // Body wasn't JSON — fall through to plain NetworkError below.
+    }
+    if (parsed?.error === UPLOAD_SESSION_NOT_FOUND_ERROR) {
+      throw new UploadSessionExpiredError(parsed.uuid ?? uuid, parsed.reason ?? 'unknown', body);
     }
   }
   throw new NetworkError(message, status, body);

--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -2,7 +2,8 @@ import type { DecryptFileResult, DecryptDataResult, SenderIdentity, SessionCallb
 import { DecryptionError, IdentityMismatchError } from '../errors.js';
 import { fetchVerificationKey } from '../api/pkg.js';
 import { getUSK } from '../api/pkg.js';
-import { downloadFile } from '../api/cryptify.js';
+import { downloadFile, downloadFileWithRetry } from '../api/cryptify.js';
+import { resolveRetryOptions, type RetryOptions } from '../util/retry.js';
 import { buildKeyRequest } from '../util/policy.js';
 import { retrieveUSKViaYivi } from '../yivi/decrypt-session.js';
 import { readZipFilenames } from '../util/zip.js';
@@ -19,6 +20,7 @@ export interface InspectSealedOptions {
   data?: Uint8Array | ReadableStream<Uint8Array>;
   signal?: AbortSignal;
   headers?: HeadersInit;
+  retry?: RetryOptions;
 }
 
 export interface InspectSealedResult {
@@ -37,9 +39,10 @@ export async function inspectSealed(options: InspectSealedOptions): Promise<Insp
 
   if (uuid && cryptifyUrl) {
     // Download from Cryptify and fetch VK in parallel
+    const retry = resolveRetryOptions(options.retry);
     const [vk, fileStream] = await Promise.all([
       fetchVerificationKey(pkgUrl, headers),
-      downloadFile(cryptifyUrl, uuid, signal),
+      downloadFileWithRetry(cryptifyUrl, uuid, retry, signal),
     ]);
     readable = fileStream;
     vkPromise = Promise.resolve(vk);

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -7,6 +7,7 @@ import { resolveSigningKeys } from './signing.js';
 import Chunker, { withTransform } from './chunker.js';
 import { createZipReadable } from '../util/zip.js';
 import { loadWasm } from '../util/wasm.js';
+import type { RetryOptions } from '../util/retry.js';
 
 const DEFAULT_UPLOAD_CHUNK_SIZE = 5_000_000;
 
@@ -31,6 +32,8 @@ export interface EncryptPipelineOptions {
   headers?: HeadersInit;
   /** Pre-resolved signing keys (skips Yivi/API key resolution if provided) */
   signingKeys?: SigningKeys;
+  /** Retry behaviour for chunk uploads. See PostGuardConfig.retry. */
+  retry?: RetryOptions;
 }
 
 /** Full encryption pipeline: sign -> policy -> ZIP -> seal -> upload */
@@ -93,6 +96,7 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
     notifyRecipients: delivery?.recipients,
     apiKey: cryptifyApiKey,
     abortSignal: effectiveSignal,
+    retry: options.retry,
     onProgress: (uploaded, last) => {
       if (onProgress) {
         const pct = totalSize > 0 ? Math.min(100, Math.round((uploaded / totalSize) * 100)) : 0;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,28 @@ export class NetworkError extends PostGuardError {
   }
 }
 
+/**
+ * Thrown when Cryptify reports the upload session is no longer known to
+ * the server — either it was idle past the configured TTL, the server
+ * was restarted, or the path UUID is malformed. Distinct from
+ * `NetworkError` so retry policies can short-circuit instead of burning
+ * the budget on something that will never recover. The user must start
+ * a new upload.
+ *
+ * `reason` mirrors Cryptify's structured 404 body
+ * (`expired_or_unknown`, `invalid_uuid`, `file_missing`).
+ */
+export class UploadSessionExpiredError extends NetworkError {
+  public readonly uuid: string;
+  public readonly reason: string;
+  constructor(uuid: string, reason: string, body: string) {
+    super(`Upload session ${uuid} is no longer known to the server (${reason})`, 404, body);
+    this.name = 'UploadSessionExpiredError';
+    this.uuid = uuid;
+    this.reason = reason;
+  }
+}
+
 export class YiviNotInstalledError extends PostGuardError {
   constructor() {
     super(

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,12 @@ export { createEnvelope } from './email/envelope.js';
 export {
   PostGuardError,
   NetworkError,
+  UploadSessionExpiredError,
   YiviNotInstalledError,
   YiviSessionError,
   DecryptionError,
   IdentityMismatchError,
 } from './errors.js';
+
+// Retry types for callers configuring transient-failure behaviour
+export type { RetryOptions, RetryEvent } from './util/retry.js';

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -51,6 +51,7 @@ export class Opened {
       data: !isUuid ? this.options.data : undefined,
       signal: isUuid ? this.options.signal : undefined,
       headers: this.config.headers,
+      retry: this.config.retry,
     });
 
     this.unsealer = unsealer;

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -97,6 +97,7 @@ export class Sealed {
       delivery: opts?.notify,
       headers: this.config.headers,
       signingKeys,
+      retry: this.config.retry,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { FriendlySender } from './util/identity.js';
+import type { RetryOptions } from './util/retry.js';
 
 // --- Config ---
 
@@ -15,7 +16,7 @@ export interface PostGuardConfig {
    * jitter. 4xx responses (including the structured `upload_session_not_found`
    * 404) and caller-driven aborts are not retried.
    */
-  retry?: import('./util/retry.js').RetryOptions;
+  retry?: RetryOptions;
 }
 
 // --- Recipients ---

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,13 @@ export interface PostGuardConfig {
   headers?: HeadersInit;
   /** Size (in bytes) of each chunk sent during upload. Defaults to 5 000 000 (5 MB). */
   uploadChunkSize?: number;
+  /**
+   * Retry behaviour for Cryptify chunk uploads and downloads. Failed chunk
+   * PUTs and download GETs are retried with exponential backoff + full
+   * jitter. 4xx responses (including the structured `upload_session_not_found`
+   * 404) and caller-driven aborts are not retried.
+   */
+  retry?: import('./util/retry.js').RetryOptions;
 }
 
 // --- Recipients ---

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -13,7 +13,14 @@ export interface RetryOptions {
   chunkTimeoutMs?: number;
   /** Per-attempt timeout for finalize. Default 120 000. */
   finalizeTimeoutMs?: number;
-  /** Per-attempt timeout for download. Default disabled — let retry budget bound it. */
+  /**
+   * Per-attempt timeout for the download GET. Default disabled — let the
+   * retry budget bound it instead. Note this only bounds the request
+   * handshake (until the response headers + body stream are returned);
+   * stream consumption happens after the call returns and is *not*
+   * affected by this timeout. If you need to cap mid-stream stalls,
+   * implement that at the stream-reader level.
+   */
   downloadTimeoutMs?: number;
   /** Notification fired when a retry is about to be attempted (after a failure, before the delay). */
   onRetry?: (info: RetryEvent) => void;

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -1,0 +1,143 @@
+import { NetworkError, UploadSessionExpiredError } from '../errors.js';
+
+export interface RetryOptions {
+  /** Total attempts including the first one. Default 5. */
+  maxAttempts?: number;
+  /** Delay before the first retry, in ms. Default 500. */
+  initialDelayMs?: number;
+  /** Cap on the (pre-jitter) exponential delay. Default 30 000. */
+  maxDelayMs?: number;
+  /** Multiplier applied to the delay between attempts. Default 2. */
+  multiplier?: number;
+  /** Per-attempt timeout for chunk PUT. Default 60 000. */
+  chunkTimeoutMs?: number;
+  /** Per-attempt timeout for finalize. Default 120 000. */
+  finalizeTimeoutMs?: number;
+  /** Per-attempt timeout for download. Default disabled — let retry budget bound it. */
+  downloadTimeoutMs?: number;
+  /** Notification fired when a retry is about to be attempted (after a failure, before the delay). */
+  onRetry?: (info: RetryEvent) => void;
+}
+
+export interface RetryEvent {
+  /** 1-indexed attempt that just failed. The next attempt will be `attempt + 1`. */
+  attempt: number;
+  maxAttempts: number;
+  /** The error that caused this retry. */
+  error: unknown;
+  /** Delay (ms) the SDK will wait before the next attempt. */
+  nextDelayMs: number;
+}
+
+export interface ResolvedRetryOptions extends Required<Omit<RetryOptions, 'onRetry' | 'downloadTimeoutMs'>> {
+  onRetry?: (info: RetryEvent) => void;
+  /** 0 means "no per-attempt timeout". */
+  downloadTimeoutMs: number;
+}
+
+export function resolveRetryOptions(opts?: RetryOptions): ResolvedRetryOptions {
+  return {
+    maxAttempts: opts?.maxAttempts ?? 5,
+    initialDelayMs: opts?.initialDelayMs ?? 500,
+    maxDelayMs: opts?.maxDelayMs ?? 30_000,
+    multiplier: opts?.multiplier ?? 2,
+    chunkTimeoutMs: opts?.chunkTimeoutMs ?? 60_000,
+    finalizeTimeoutMs: opts?.finalizeTimeoutMs ?? 120_000,
+    downloadTimeoutMs: opts?.downloadTimeoutMs ?? 0,
+    onRetry: opts?.onRetry,
+  };
+}
+
+/** Outcome of inspecting an error from a retriable operation. */
+export type RetryClassification = 'retry' | 'fail';
+
+/**
+ * Decide whether an error from a Cryptify request should trigger a retry.
+ * Caller-driven aborts always fail (preserve user intent). Internal-timeout
+ * aborts retry (that's the whole point of having a timeout). 5xx and
+ * fetch-level network errors retry. 4xx fail — including the structured
+ * `upload_session_not_found` 404 surfaced as `UploadSessionExpiredError`.
+ */
+export function classifyCryptifyError(err: unknown, callerSignal?: AbortSignal): RetryClassification {
+  if (err instanceof UploadSessionExpiredError) return 'fail';
+  if (err instanceof NetworkError) {
+    return err.status >= 500 ? 'retry' : 'fail';
+  }
+  if (err instanceof DOMException && err.name === 'AbortError') {
+    return callerSignal?.aborted ? 'fail' : 'retry';
+  }
+  // TypeError covers fetch's "Failed to fetch" / network unreachable.
+  if (err instanceof TypeError) return 'retry';
+  return 'fail';
+}
+
+function delayWithFullJitter(opts: ResolvedRetryOptions, attempt: number): number {
+  const base = Math.min(opts.initialDelayMs * Math.pow(opts.multiplier, attempt - 1), opts.maxDelayMs);
+  return Math.floor(Math.random() * base);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const t = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      reject(signal?.reason ?? new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Run `fn` up to `opts.maxAttempts` times, retrying on retriable failures
+ * with exponential backoff and full jitter. The caller's `signal` aborts
+ * the loop synchronously and propagates as an AbortError.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  opts: ResolvedRetryOptions,
+  classify: (err: unknown) => RetryClassification = classifyCryptifyError,
+  callerSignal?: AbortSignal
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      lastError = err;
+      if (callerSignal?.aborted) throw err;
+      if (attempt >= opts.maxAttempts) break;
+      if (classify(err) === 'fail') break;
+      const nextDelayMs = delayWithFullJitter(opts, attempt);
+      opts.onRetry?.({ attempt, maxAttempts: opts.maxAttempts, error: err, nextDelayMs });
+      await sleep(nextDelayMs, callerSignal);
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Combine a caller-provided AbortSignal with a per-attempt timeout. Returns
+ * `{ signal, cleanup }` — call `cleanup()` after the awaited operation
+ * resolves to release the timer.
+ */
+export function withTimeout(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number
+): { signal: AbortSignal | undefined; cleanup: () => void } {
+  if (timeoutMs <= 0) {
+    return { signal: callerSignal, cleanup: () => {} };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, controller.signal])
+    : controller.signal;
+  return { signal, cleanup: () => clearTimeout(timer) };
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,12 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { NetworkError } from '../src/errors.js';
+import { NetworkError, UploadSessionExpiredError } from '../src/errors.js';
 import { fetchMPK, fetchVerificationKey, fetchSigningKeysWithApiKey } from '../src/api/pkg.js';
-import { initUpload, storeChunk, finalizeUpload, downloadFile } from '../src/api/cryptify.js';
+import {
+  initUpload,
+  storeChunk,
+  storeChunkWithRetry,
+  finalizeUpload,
+  downloadFile,
+  downloadFileWithRetry,
+} from '../src/api/cryptify.js';
+import { resolveRetryOptions } from '../src/util/retry.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
 
 beforeEach(() => {
+  mockFetch.mockReset();
   vi.stubGlobal('fetch', mockFetch);
 });
 
@@ -208,6 +217,233 @@ describe('Cryptify API', () => {
         })
       );
     });
+
+    it('surfaces upload_session_not_found 404 as UploadSessionExpiredError', async () => {
+      const body = JSON.stringify({
+        error: 'upload_session_not_found',
+        uuid: 'file-uuid',
+        reason: 'expired_or_unknown',
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve(body),
+        headers: new Headers(),
+      });
+
+      await expect(
+        storeChunk(
+          'https://cryptify.example.com',
+          { token: 'tok', uuid: 'file-uuid' },
+          new Uint8Array([1]),
+          0
+        )
+      ).rejects.toMatchObject({
+        name: 'UploadSessionExpiredError',
+        status: 404,
+        uuid: 'file-uuid',
+        reason: 'expired_or_unknown',
+      });
+    });
+
+    it('plain 404 (non-structured body) still falls through as NetworkError', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('plain 404 body'),
+        headers: new Headers(),
+      });
+
+      const err = await storeChunk(
+        'https://cryptify.example.com',
+        { token: 'tok', uuid: 'u' },
+        new Uint8Array([1]),
+        0
+      ).catch((e) => e);
+
+      expect(err).toBeInstanceOf(NetworkError);
+      expect(err).not.toBeInstanceOf(UploadSessionExpiredError);
+      expect(err.status).toBe(404);
+    });
+  });
+
+  describe('storeChunkWithRetry', () => {
+    const fastRetry = resolveRetryOptions({
+      maxAttempts: 3,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+      multiplier: 2,
+    });
+
+    it('returns the new token on first-attempt success', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ cryptifytoken: 'tok-after' }),
+      });
+
+      const result = await storeChunkWithRetry(
+        'https://cryptify.example.com',
+        { token: 'tok-before', uuid: 'u' },
+        new Uint8Array([1]),
+        0,
+        fastRetry
+      );
+
+      expect(result.token).toBe('tok-after');
+      expect(result.prevToken).toBe('tok-before');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 503 and succeeds on the next attempt', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('busy'),
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ cryptifytoken: 'tok-after' }),
+        });
+
+      const result = await storeChunkWithRetry(
+        'https://cryptify.example.com',
+        { token: 'tok-before', uuid: 'u' },
+        new Uint8Array([1]),
+        0,
+        fastRetry
+      );
+
+      expect(result.token).toBe('tok-after');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends prevToken on retry so cryptify can detect a duplicate', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ cryptifytoken: 'tok-after' }),
+        });
+
+      const result = await storeChunkWithRetry(
+        'https://cryptify.example.com',
+        { token: 'tok-current', prevToken: 'tok-prev', uuid: 'u' },
+        new Uint8Array([1]),
+        0,
+        fastRetry
+      );
+
+      expect(result.token).toBe('tok-after');
+      // Attempt 1 sends `state.token` (tok-current).
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://cryptify.example.com/fileupload/u',
+        expect.objectContaining({
+          headers: expect.objectContaining({ cryptifytoken: 'tok-current' }),
+        })
+      );
+      // Attempt 2 sends `state.prevToken` (tok-prev) so cryptify's
+      // idempotent-retry path replays the cached response if the original
+      // PUT had been committed before the response was lost.
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://cryptify.example.com/fileupload/u',
+        expect.objectContaining({
+          headers: expect.objectContaining({ cryptifytoken: 'tok-prev' }),
+        })
+      );
+    });
+
+    it('does NOT retry on UploadSessionExpiredError (4xx fail-fast)', async () => {
+      const body = JSON.stringify({
+        error: 'upload_session_not_found',
+        uuid: 'u',
+        reason: 'expired_or_unknown',
+      });
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve(body),
+        headers: new Headers(),
+      });
+
+      await expect(
+        storeChunkWithRetry(
+          'https://cryptify.example.com',
+          { token: 't', uuid: 'u' },
+          new Uint8Array([1]),
+          0,
+          fastRetry
+        )
+      ).rejects.toBeInstanceOf(UploadSessionExpiredError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry on 413 (quota exceeded)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 413,
+        text: () => Promise.resolve('{"error":"per_upload"}'),
+        headers: new Headers(),
+      });
+
+      await expect(
+        storeChunkWithRetry(
+          'https://cryptify.example.com',
+          { token: 't', uuid: 'u' },
+          new Uint8Array([1]),
+          0,
+          fastRetry
+        )
+      ).rejects.toMatchObject({ name: 'NetworkError', status: 413 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts maxAttempts on persistent 503 then throws the last error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: () => Promise.resolve('busy'),
+        headers: new Headers(),
+      });
+
+      await expect(
+        storeChunkWithRetry(
+          'https://cryptify.example.com',
+          { token: 't', uuid: 'u' },
+          new Uint8Array([1]),
+          0,
+          fastRetry
+        )
+      ).rejects.toMatchObject({ name: 'NetworkError', status: 503 });
+      expect(mockFetch).toHaveBeenCalledTimes(fastRetry.maxAttempts);
+    });
+
+    it('does NOT retry when the caller-provided AbortSignal aborts', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      mockFetch.mockRejectedValueOnce(
+        new DOMException('Aborted', 'AbortError')
+      );
+
+      await expect(
+        storeChunkWithRetry(
+          'https://cryptify.example.com',
+          { token: 't', uuid: 'u' },
+          new Uint8Array([1]),
+          0,
+          fastRetry,
+          controller.signal
+        )
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('finalizeUpload', () => {
@@ -312,6 +548,53 @@ describe('Cryptify API', () => {
       await expect(
         downloadFile('https://cryptify.example.com', 'uuid')
       ).rejects.toThrow('Response body is null');
+    });
+  });
+
+  describe('downloadFileWithRetry', () => {
+    const fastRetry = resolveRetryOptions({
+      maxAttempts: 3,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+    });
+
+    it('retries on 502 and succeeds on the next attempt', async () => {
+      const stream = new ReadableStream();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 502,
+          text: () => Promise.resolve('bad gateway'),
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: stream,
+        });
+
+      const result = await downloadFileWithRetry(
+        'https://cryptify.example.com',
+        'uuid',
+        fastRetry
+      );
+
+      expect(result).toBe(stream);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry on 404', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('not found'),
+        headers: new Headers(),
+      });
+
+      await expect(
+        downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry)
+      ).rejects.toMatchObject({ name: 'NetworkError', status: 404 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Cryptify chunk PUTs and downloads now retry transient failures automatically. The retry budget, delays, and per-phase timeouts are configurable via `PostGuardConfig.retry`; defaults are 5 attempts, 500 ms initial delay, 30 s cap, 2× multiplier with full jitter.

This is the client side of a coordinated change with cryptify. The server-side counterpart shipped in encryption4all/cryptify#145 (idempotent chunk retry — server caches the just-committed chunk and replays the cached response token when it sees a duplicate). Without that contract a naïve client retry would corrupt the rolling `CryptifyToken` chain; with it, an in-flight response loss is recoverable transparently.

### What changed

- New `src/util/retry.ts` — exponential backoff with full jitter, retry classification, per-attempt timeout helper.
- `storeChunkWithRetry` and `downloadFileWithRetry` wrap the existing single-shot calls in `src/api/cryptify.ts`. `initUpload` and `finalizeUpload` deliberately do **not** retry (idempotency unclear, lower value).
- `FileState` gains a `prevToken` field. The retry loop sends `currentToken` on attempt 1 and `prevToken` on subsequent attempts, exercising cryptify#145's idempotent-retry path.
- New `UploadSessionExpiredError` (NetworkError subclass) parsed from cryptify's structured 404 body (`upload_session_not_found`). Distinct from `NetworkError` so retry policies short-circuit instead of burning budget on something that will never recover. Surfaced from both chunk and finalize.
- Per-phase timeouts: `chunkTimeoutMs` (60 s default), `finalizeTimeoutMs` (120 s default, replaces the previous hardcoded value), `downloadTimeoutMs` (off by default — let retry budget bound it rather than cutting off mid-stream).
- `RetryOptions` plumbed through `PostGuardConfig` → `Sealed.upload` / `Opened.decrypt` → `encryptPipeline` / `inspectSealed`.
- New `RetryEvent` type and an `onRetry` hook for UI to surface "retrying… (attempt N of M)" without re-implementing classification.

### Retry classification

- **Retry**: 5xx, fetch-level network errors (`TypeError`), AbortError caused by an internal timeout (not the caller's signal).
- **Fail**: 4xx (including 413 quota), `UploadSessionExpiredError`, caller-driven aborts.

### Wire compatibility

The new error is opt-in — old cryptify deployments keep returning bare 404s, which surface as plain `NetworkError(404)` (so existing 404-handling code paths still work). Once a deployment includes cryptify#144's structured body, this SDK upgrades the error to `UploadSessionExpiredError` automatically.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 66 tests pass (was 55 before; 11 new mocked-network cases)
- [x] First-attempt success returns expected token
- [x] 503 then 200 → retry succeeds, both attempts observed
- [x] Network error (`TypeError`) then 200 → retry succeeds
- [x] Retry sends `prevToken` on attempt 2 (the cryptify#145 contract)
- [x] 404 with `upload_session_not_found` body → `UploadSessionExpiredError`, not retried
- [x] 413 → `NetworkError(413)`, not retried
- [x] Persistent 503 → exhausts `maxAttempts`, throws last error
- [x] Caller-driven abort → no retry, throws `AbortError`
- [x] `downloadFileWithRetry`: 502 then 200 → retry succeeds
- [x] `downloadFileWithRetry`: 404 → not retried
- [x] Manual: against a local cryptify, throttle to "Slow 3G" in DevTools and confirm retries succeed transparently
- [x] Manual: kill cryptify mid-upload after a chunk write completes → confirm SDK retries with `prevToken` and the upload completes (proves cryptify#145 ↔ this PR end-to-end)
- [x] Manual: stop cryptify entirely → confirm SDK retries `maxAttempts` then surfaces a clear error

## Refs

- Pairs with encryption4all/cryptify#145 (server-side idempotent retry — merged)
- Builds on encryption4all/cryptify#144 (structured 404 — merged)
- Issue encryption4all/postguard-website#117 (upload robustness — root cause)

Cross-refresh resume (persisting upload state across page reload) and SDK-side resumable downloads via Range will be filed as separate issues — they require different infrastructure and aren't in scope here.