### PR TITLE
chore(deps): bump @privacybydesign/yivi-* to 1.0.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@e4a/pg-wasm": "^0.5.10",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
         "@transcend-io/conflux": "^6.1.3"
       },
       "devDependencies": {
@@ -199,40 +199,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-1B0NryDau4rkv6w6Y2eLesoynuVvKNEKC/6MZPdPMDo8ecnN02bZM+gpogqO0Th94NKK+iXtRREqKWaopXJhIQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
+      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-xkwTLfVRnGW7RTLjPMvLYbnvYz/ULpZZnzKJwXP9zNdHup0Ol2JGN83dIvq979CtG2vdJUeh8hOoQfPsFaiqnQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.4.tgz",
-      "integrity": "sha512-ccV8Wb39gChj9t6nYugYrd5QVvsC9AmQhonsEkBVUX3JQavZVeowTX4Y+VBonJVDfPAvPLaqUdlnVhIDnRLPvA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
+      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.4.tgz",
-      "integrity": "sha512-+TMKX1NlHHAD3Lk8MFDcATzDK4muc/1zmyKD3Nwfk8WRb4p2RNNeqwCvztVmZ6V8OVGFFJOT2gMPRv/Z/e2egA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
+      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@quansync/fs": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   },
   "dependencies": {
     "@e4a/pg-wasm": "^0.5.10",
-    "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-    "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-    "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-    "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+    "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+    "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+    "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+    "@privacybydesign/yivi-web": "^1.0.0-beta.5",
     "@transcend-io/conflux": "^6.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps the four `@privacybydesign/yivi-*` runtime deps from `^1.0.0-beta.4` to `^1.0.0-beta.5`:

- `@privacybydesign/yivi-client`
- `@privacybydesign/yivi-core`
- `@privacybydesign/yivi-css`
- `@privacybydesign/yivi-web`

`1.0.0-beta.5` is the latest beta — see [yivi-frontend-packages release notes](https://github.com/privacybydesign/yivi-frontend-packages). Once this is merged and `@e4a/pg-js` ships a new version, downstream consumers (`postguard-business`, `postguard-tb-addon`, `postguard-docs`, etc.) will pick up the bump transitively.

No code changes; just `package.json` + lockfile.

## Test plan

- [ ] CI green
- [ ] Verify the bundled yivi flow still works in the postguard-js demo / examples