### PR TITLE
ci: add semantic PR title check workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,14 @@
+name: PR Title
+
+on:
+    pull_request:
+        types: [opened, edited, synchronize, reopened]
+
+jobs:
+    lint-pr-title:
+        name: Conventional Commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-title.yml` running `amannn/action-semantic-pull-request@v5` on every PR.
- Enforces Conventional Commit format on PR titles (`feat:`, `fix:`, `chore:`, etc.) for consistent changelogs and release tooling.
- Mirrors the workflow already in use at `postguard-website` so org repos stay aligned.

Closes #49.

## Test plan
- [ ] CI runs the new `PR Title` workflow on this PR and reports status.
- [ ] Verify the check fails on a non-conventional title and re-runs after editing the title.