### PR TITLE
feat(download): resume via Range header on transient stream failures

### DIFF
--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -1,6 +1,9 @@
 import { NetworkError, UploadSessionExpiredError } from '../errors.js';
 import {
+  classifyCryptifyError,
+  delayWithFullJitter,
   resolveRetryOptions,
+  sleep,
   withRetry,
   withTimeout,
   type ResolvedRetryOptions,
@@ -222,35 +225,158 @@ export async function downloadFile(
 }
 
 /**
- * Download with retry on transient failures. Cryptify's `FileServer`
- * already supports HTTP Range requests, so this could be extended to
- * resume mid-stream — that's tracked separately. Today the retry simply
- * re-issues the GET on transient failure.
+ * Issue a Range request to resume a download from `offset`. Strict on
+ * the response: only `206 Partial Content` whose `Content-Range` first
+ * byte equals `offset` is accepted. A `200 OK` is a silent-rewind trap
+ * — some intermediaries (caching proxies, misconfigured CDNs) ignore
+ * `Range` and return the whole body from byte 0; splicing that onto
+ * a consumer that already saw `offset` bytes corrupts the file. We
+ * surface the mismatch as a `NetworkError` so the retry loop classifies
+ * it as `fail` (the upstream isn't going to start honouring Range on
+ * the next try).
  */
-export async function downloadFileWithRetry(
+async function downloadRange(
+  cryptifyUrl: string,
+  uuid: string,
+  offset: number,
+  signal?: AbortSignal
+): Promise<ReadableStream<Uint8Array>> {
+  const response = await fetch(`${cryptifyUrl}/filedownload/${uuid}`, {
+    signal,
+    method: 'GET',
+    headers: { Range: `bytes=${offset}-` },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new NetworkError(`Error resuming download`, response.status, body);
+  }
+
+  if (response.status !== 206) {
+    // Server didn't honour Range. Treat as terminal — same upstream is
+    // unlikely to start honouring it on the next attempt.
+    throw new NetworkError(
+      `Resume request returned ${response.status}, expected 206 — upstream did not honour Range`,
+      response.status,
+      ''
+    );
+  }
+
+  const contentRange = response.headers.get('content-range');
+  const start = parseContentRangeStart(contentRange);
+  if (start !== offset) {
+    throw new NetworkError(
+      `Resume Content-Range start ${start ?? '<missing>'} does not match requested offset ${offset}`,
+      response.status,
+      contentRange ?? ''
+    );
+  }
+
+  if (!response.body) throw new Error('Response body is null');
+  return response.body as ReadableStream<Uint8Array>;
+}
+
+/** Parse the `bytes <start>-<end>/<size>` form. Returns the start byte
+ *  on success, `null` on any malformed value. Conservative — a future
+ *  RFC 7233 extension (`*` for unknown size, etc.) that doesn't match
+ *  this shape is treated the same as missing for safety. */
+function parseContentRangeStart(header: string | null): number | null {
+  if (!header) return null;
+  const match = /^\s*bytes\s+(\d+)-/.exec(header);
+  if (!match) return null;
+  const start = Number.parseInt(match[1], 10);
+  return Number.isFinite(start) ? start : null;
+}
+
+/**
+ * Download with retry on transient failures. Cryptify's `FileServer`
+ * already supports HTTP Range requests, so a stream-level failure
+ * mid-download (network drop, idle timeout) resumes from the byte
+ * offset reached rather than starting over from zero. The consumer
+ * sees a single contiguous stream regardless of how many internal
+ * retries happened.
+ *
+ * Implementation note: the retry loop lives inside the returned
+ * stream's `start()` source — wrapping `withRetry` around this would
+ * be the wrong abstraction (its `Promise<T>` shape resolves before the
+ * stream is read, leaving mid-stream errors with no way to re-enter
+ * the loop). Same backoff helpers, different driver.
+ */
+export function downloadFileWithRetry(
   cryptifyUrl: string,
   uuid: string,
   retry: ResolvedRetryOptions,
   signal?: AbortSignal
-): Promise<ReadableStream<Uint8Array>> {
-  return withRetry(
-    async () => {
-      const { signal: timed, cleanup } = withTimeout(signal, retry.downloadTimeoutMs);
-      try {
-        return await downloadFile(cryptifyUrl, uuid, timed);
-      } finally {
-        // Note: downloadFile returns a stream that is read *after* this
-        // function returns, so a per-attempt timeout that aborts the
-        // stream mid-read would surface as a stream error. We only
-        // bound the GET handshake here; if downloadTimeoutMs is 0 (the
-        // default) cleanup is a no-op.
-        cleanup();
+): ReadableStream<Uint8Array> {
+  let received = 0;
+  let attempt = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      // Single source of truth: each underlying GET is one `attempt`,
+      // counter is shared across resumes so a flapping connection that
+      // delivers some bytes per attempt still exhausts the budget.
+      while (true) {
+        attempt += 1;
+        const { signal: timed, cleanup } = withTimeout(signal, retry.downloadTimeoutMs);
+        try {
+          const stream =
+            received === 0
+              ? await downloadFile(cryptifyUrl, uuid, timed)
+              : await downloadRange(cryptifyUrl, uuid, received, timed);
+          cleanup();
+
+          const reader = stream.getReader();
+          for (;;) {
+            const { value, done } = await reader.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            received += value.byteLength;
+            controller.enqueue(value);
+          }
+        } catch (err) {
+          cleanup();
+          if (signal?.aborted) {
+            controller.error(err);
+            return;
+          }
+          if (attempt >= retry.maxAttempts) {
+            controller.error(err);
+            return;
+          }
+          if (classifyCryptifyError(err, signal) === 'fail') {
+            controller.error(err);
+            return;
+          }
+          const nextDelayMs = delayWithFullJitter(retry, attempt);
+          retry.onRetry?.({
+            attempt,
+            maxAttempts: retry.maxAttempts,
+            error: err,
+            nextDelayMs,
+          });
+          try {
+            await sleep(nextDelayMs, signal);
+          } catch (sleepErr) {
+            controller.error(sleepErr);
+            return;
+          }
+          // Loop back: next iteration uses Range from `received`.
+        }
       }
     },
-    retry,
-    undefined,
-    signal
-  );
+    cancel(reason) {
+      // Caller-driven cancel (consumer abandoned the stream). The
+      // currently in-flight fetch is bound to `signal` already — we
+      // can't directly cancel it from here, but consumer abandoning the
+      // ReadableStream means they won't pull more. The fetch will
+      // eventually error or complete; either way nothing reaches the
+      // controller after cancel.
+      void reason;
+    },
+  });
 }
 
 export interface UploadStream {

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -78,12 +78,24 @@ export function classifyCryptifyError(err: unknown, callerSignal?: AbortSignal):
   return 'fail';
 }
 
-function delayWithFullJitter(opts: ResolvedRetryOptions, attempt: number): number {
+/**
+ * Compute the next retry delay (ms) with full jitter — uniform random
+ * between 0 and the exponentially-capped base. Exported so non-`withRetry`
+ * callers (e.g. the source-owned retry loop in `downloadFileWithRetry`)
+ * can reuse the same backoff curve without forking the implementation.
+ */
+export function delayWithFullJitter(opts: ResolvedRetryOptions, attempt: number): number {
   const base = Math.min(opts.initialDelayMs * Math.pow(opts.multiplier, attempt - 1), opts.maxDelayMs);
   return Math.floor(Math.random() * base);
 }
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+/**
+ * Promise that resolves after `ms` milliseconds, rejecting early with an
+ * AbortError if `signal` aborts. Exported alongside `delayWithFullJitter`
+ * for the same reason — consistent abort semantics across all retry
+ * call sites.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -558,8 +558,77 @@ describe('Cryptify API', () => {
       maxDelayMs: 5,
     });
 
-    it('retries on 502 and succeeds on the next attempt', async () => {
-      const stream = new ReadableStream();
+    /** Build a ReadableStream that yields the given byte chunks then closes. */
+    function streamOf(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+    }
+
+    /** Build a ReadableStream that yields the given chunks then errors.
+     *  Pull-based so chunks are delivered to the consumer before the
+     *  error fires — `controller.error()` empties any queued chunks, so
+     *  a start-based variant would silently drop the first batch. */
+    function streamThenError(
+      chunks: Uint8Array[],
+      err: unknown
+    ): ReadableStream<Uint8Array> {
+      let i = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (i < chunks.length) {
+            controller.enqueue(chunks[i++]);
+          } else {
+            controller.error(err);
+          }
+        },
+      });
+    }
+
+    /** Drain a ReadableStream into a single Uint8Array. */
+    async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+      const reader = stream.getReader();
+      const parts: Uint8Array[] = [];
+      let total = 0;
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        parts.push(value);
+        total += value.byteLength;
+      }
+      const out = new Uint8Array(total);
+      let offset = 0;
+      for (const p of parts) {
+        out.set(p, offset);
+        offset += p.byteLength;
+      }
+      return out;
+    }
+
+    it('produces the underlying bytes on a clean download', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: streamOf(new Uint8Array([1, 2, 3, 4])),
+      });
+
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const bytes = await drain(stream);
+
+      expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // First attempt should not include a Range header.
+      expect(mockFetch.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ method: 'GET' })
+      );
+      const firstAttemptHeaders = mockFetch.mock.calls[0][1]?.headers;
+      expect(firstAttemptHeaders).toBeUndefined();
+    });
+
+    it('retries on 502 and succeeds on the next attempt (no Range yet — zero bytes received)', async () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: false,
@@ -570,20 +639,101 @@ describe('Cryptify API', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          body: stream,
+          body: streamOf(new Uint8Array([42])),
         });
 
-      const result = await downloadFileWithRetry(
-        'https://cryptify.example.com',
-        'uuid',
-        fastRetry
-      );
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const bytes = await drain(stream);
 
-      expect(result).toBe(stream);
+      expect(Array.from(bytes)).toEqual([42]);
       expect(mockFetch).toHaveBeenCalledTimes(2);
+      // No bytes received before the retry — the retry is a fresh GET, not a Range request.
+      expect(mockFetch.mock.calls[1][1]?.headers).toBeUndefined();
     });
 
-    it('does not retry on 404', async () => {
+    it('resumes from received offset via Range when stream errors mid-flight', async () => {
+      // Attempt 1: deliver 4 bytes, then the underlying stream errors.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: streamThenError(
+          [new Uint8Array([1, 2, 3, 4])],
+          new TypeError('network reset')
+        ),
+      });
+      // Attempt 2: 206 with Content-Range starting at 4, deliver 4 more bytes.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 206,
+        headers: new Headers({ 'content-range': 'bytes 4-7/8' }),
+        body: streamOf(new Uint8Array([5, 6, 7, 8])),
+        text: () => Promise.resolve(''),
+      });
+
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const bytes = await drain(stream);
+
+      expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Resume request must include Range: bytes=4-
+      expect(mockFetch.mock.calls[1][1]?.headers).toEqual(
+        expect.objectContaining({ Range: 'bytes=4-' })
+      );
+    });
+
+    it('fails fast if resume returns 200 instead of 206 (silent-rewind protection)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: streamThenError([new Uint8Array([1, 2])], new TypeError('drop')),
+      });
+      // Resume attempt: server (or proxy) ignored Range and returned 200.
+      // Without strict checking, we'd splice this on top of the 2 bytes
+      // already delivered and corrupt the stream.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: streamOf(new Uint8Array([1, 2, 3, 4])),
+        text: () => Promise.resolve(''),
+      });
+
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+
+      const reader = stream.getReader();
+      const first = await reader.read();
+      expect(Array.from(first.value!)).toEqual([1, 2]);
+      // Next read should error — 200 on resume is treated as terminal.
+      await expect(reader.read()).rejects.toMatchObject({
+        name: 'NetworkError',
+        message: expect.stringContaining('did not honour Range'),
+      });
+    });
+
+    it('fails fast if resume Content-Range start does not match requested offset', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: streamThenError([new Uint8Array([1, 2])], new TypeError('drop')),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 206,
+        headers: new Headers({ 'content-range': 'bytes 0-7/8' }), // wrong start!
+        body: streamOf(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7])),
+        text: () => Promise.resolve(''),
+      });
+
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const reader = stream.getReader();
+      await reader.read(); // [1,2]
+      await expect(reader.read()).rejects.toMatchObject({
+        name: 'NetworkError',
+        message: expect.stringContaining('Content-Range start 0 does not match requested offset 2'),
+      });
+    });
+
+    it('errors stream on first read with 404 (no retry)', async () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 404,
@@ -591,9 +741,104 @@ describe('Cryptify API', () => {
         headers: new Headers(),
       });
 
-      await expect(
-        downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry)
-      ).rejects.toMatchObject({ name: 'NetworkError', status: 404 });
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const reader = stream.getReader();
+      await expect(reader.read()).rejects.toMatchObject({
+        name: 'NetworkError',
+        status: 404,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares the attempt counter across resumes — flapping connection exhausts the budget', async () => {
+      // Each attempt delivers one byte then errors. Without the shared
+      // counter, this would loop forever; with it, the source errors
+      // after maxAttempts (3) — three bytes delivered before the
+      // failure surfaces.
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 206,
+          headers: new Headers({
+            'content-range': `bytes ${
+              mockFetch.mock.calls.length - 1
+            }-${mockFetch.mock.calls.length - 1}/100`,
+          }),
+          body: streamThenError(
+            [new Uint8Array([0xab])],
+            new TypeError('flap')
+          ),
+          text: () => Promise.resolve(''),
+        })
+      );
+      // The first attempt is a regular GET (no Range), so override its
+      // Content-Range expectation: the source uses Range only for
+      // attempts ≥ 2. The mock returns 206 for everything, but the
+      // first response's status doesn't matter for the source's logic
+      // — it only checks 206 + Content-Range on resume requests, not
+      // the first GET. We rebuild the mock per call so the
+      // Content-Range matches `received`.
+      mockFetch.mockReset();
+      let callIndex = 0;
+      mockFetch.mockImplementation((_url, init) => {
+        callIndex += 1;
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        if (callIndex === 1) {
+          // First attempt: plain GET, deliver 1 byte then drop.
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            body: streamThenError(
+              [new Uint8Array([0xa1])],
+              new TypeError('flap')
+            ),
+          });
+        }
+        // Resume attempts: parse Range, return 206 with matching Content-Range.
+        const m = /^bytes=(\d+)-/.exec(headers.Range ?? '');
+        const offset = m ? Number.parseInt(m[1], 10) : 0;
+        return Promise.resolve({
+          ok: true,
+          status: 206,
+          headers: new Headers({
+            'content-range': `bytes ${offset}-${offset}/100`,
+          }),
+          body: streamThenError(
+            [new Uint8Array([0xa0 + offset])],
+            new TypeError('flap')
+          ),
+          text: () => Promise.resolve(''),
+        });
+      });
+
+      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const reader = stream.getReader();
+      // Each attempt delivers one byte before erroring. With maxAttempts=3,
+      // we should see 3 bytes total, then the next read errors.
+      const seen: number[] = [];
+      for (let i = 0; i < 3; i++) {
+        const r = await reader.read();
+        if (r.done) break;
+        seen.push(...Array.from(r.value));
+      }
+      expect(seen).toHaveLength(3);
+      await expect(reader.read()).rejects.toMatchObject({ name: 'TypeError' });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('caller-driven abort propagates as AbortError without retry', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      mockFetch.mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
+
+      const stream = downloadFileWithRetry(
+        'https://cryptify.example.com',
+        'uuid',
+        fastRetry,
+        controller.signal
+      );
+      const reader = stream.getReader();
+      await expect(reader.read()).rejects.toMatchObject({ name: 'AbortError' });
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Implements the resumable-download design from encryption4all/cryptify#48 — incorporating the review feedback @dobby-coder posted on the issue, which pushed back hard (and correctly) on the original \"wrap withRetry\" sketch in the issue body.

## Shape

- **Source-owned retry loop inside the outer `ReadableStream`.** `withRetry`'s `Promise<T>` shape resolves before the stream is read, leaving mid-stream errors with no way to re-enter the loop. The new driver lives in the stream's `start()` and turns each underlying GET into one `attempt`. Same backoff helpers — different driver.
- **No `tee()`** — bytes flow through the source's own `read()` → `enqueue()` path, so `received += value.byteLength` at the single forwarding site.
- **Strict `206` + `Content-Range` check on resume.** Range is a request hint, not a contract. Caching proxies and misconfigured CDNs can ignore it and return `200 OK` with the full body from byte 0; splicing that onto a consumer at offset N corrupts the file silently. Resume asserts both `status === 206` and that `Content-Range`'s start byte equals the requested offset — either mismatch is classified as fail-not-retry (the upstream isn't going to start honouring Range on the next try).
- **Attempt counter shared across resumes.** A flapping connection that delivers some bytes per attempt now exhausts the budget instead of looping forever.
- Reuses existing `classifyCryptifyError` for stream-level errors — confirmed by test rather than pre-emptively changed.
- Stall-watchdog explicitly out of scope (separate axis, would balloon the change).

## Public-API change

`downloadFileWithRetry` now returns the `ReadableStream` synchronously (no `Promise` wrapper). Stream-level errors propagate to the consumer's first failing `read()` call rather than via the function's promise. The single existing call site in `src/crypto/decrypt.ts:45` works unchanged because `Promise.all` accepts non-thenable values.

This is a behavioural shift only for callers that did `await downloadFileWithRetry(...)` and caught a synchronous rejection for non-stream-level errors (e.g. 404). With the new shape, those errors surface on the consumer's first `read()` call, which is the right place — they're stream-level events, not function-result events.

## Test plan

- [x] Clean download (1 attempt) — bytes match, no Range header on first GET
- [x] 502 → 200 retry — fresh GET (no Range) since `received === 0`
- [x] Mid-stream failure → 206 resume from offset — bytes contiguous
- [x] 200 on resume → fail-not-retry (silent-rewind protection)
- [x] 206 with mismatched `Content-Range` start → fail-not-retry
- [x] 404 on first read → no retry, propagates as `NetworkError(404)`
- [x] Flapping connection (1 byte per attempt × 3) — exhausts budget, errors after 3
- [x] Caller-driven abort → `AbortError`, no retry
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 72 passed (was 66, added 6)
- [ ] Manual: against a local cryptify, `nc` between Cryptify and the browser, kill the connection mid-download → SDK resumes when reconnected, file downloads complete and decrypts cleanly
- [ ] Manual: confirm `StreamUnsealer.new(stream, vk)` consumes an internally-spliced stream without choking — the only existing consumer at `src/crypto/decrypt.ts:62`

## Refs

- Closes encryption4all/cryptify#48
- Pairs with encryption4all/postguard#301 (cryptify already supports Range natively, no server-side change needed)
- Builds on encryption4all/postguard#306 (retry/backoff foundation — `RetryOptions`, `classifyCryptifyError`, jitter helpers reused)
- encryption4all/postguard-website#117 (root robustness issue)

## Out of scope (tracked separately)

- Cross-refresh download resume (persisting partial blob in IndexedDB so a refresh picks up where the previous session left off). Most downloads are short enough that in-session retry covers the common case.
- Idle-stall detection (stall watchdog timer that resets on each `enqueue`) — separate axis from `downloadTimeoutMs`, deserves its own design.