### PR TITLE
chore: bump @privacybydesign/yivi-* to 1.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@e4a/pg-wasm": "^0.5.10",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.6",
         "@transcend-io/conflux": "^6.1.3"
       },
       "devDependencies": {
@@ -199,40 +199,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
-      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.6.tgz",
+      "integrity": "sha512-oiplBNmU7cZkxQkynB9Sf4U363Cn4XXoF9NnvWO2qeLoCudpxI7e96zcZW91GASPxFyW7vjJKTNUepkX6N01nA==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
-      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.6.tgz",
+      "integrity": "sha512-uHdiV+xlYYLvK49nPpvOYXR1xBJX7WDY7jSVGVLdLRW4qlY4D2UCGgESejxOTY825Mp5TVs4O2E7qrMnvIWLUQ==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
-      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.6.tgz",
+      "integrity": "sha512-dBewDFIMRsf6tOs8RvkCUQPOgNASazApK1HCvAXmkPvTUaMfBONvgBOuUZ/QPKawsTxiCOmMgCm7+746YsgL+Q==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
-      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.6.tgz",
+      "integrity": "sha512-rYD45/YLDD0sfKsIPISDaPU8nCGnax7Q195fyQtP3XpyfD6S5Z5ciRXN5kydHg2izg7Ld4+V9IpgjwMCtAst/g==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@quansync/fs": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   },
   "dependencies": {
     "@e4a/pg-wasm": "^0.5.10",
-    "@privacybydesign/yivi-client": "^1.0.0-beta.5",
-    "@privacybydesign/yivi-core": "^1.0.0-beta.5",
-    "@privacybydesign/yivi-css": "^1.0.0-beta.5",
-    "@privacybydesign/yivi-web": "^1.0.0-beta.5",
+    "@privacybydesign/yivi-client": "^1.0.0-beta.6",
+    "@privacybydesign/yivi-core": "^1.0.0-beta.6",
+    "@privacybydesign/yivi-css": "^1.0.0-beta.6",
+    "@privacybydesign/yivi-web": "^1.0.0-beta.6",
     "@transcend-io/conflux": "^6.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps yivi-client, yivi-core, yivi-css, yivi-web from `^1.0.0-beta.5` to `^1.0.0-beta.6`.

The new beta renders the QR as SVG for crisp resizing at any size (yivi-frontend-packages commit fd7fcd6).

## Test plan
- [ ] `npm install` succeeds
- [ ] Build and tests pass
- [ ] QR code displays sharp at all sizes in consumers