### PR TITLE
feat(upload): info notice when notify is unset on first upload

### DIFF
--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -83,6 +83,23 @@ export class Sealed {
 
     validateUploadOptions(opts);
 
+    // Surface the silent-by-default behaviour once per PostGuard instance.
+    // The most common "the SDK didn't send my email" support case is a
+    // caller who didn't realise notify defaults to silent — TypeScript
+    // can't catch it because `notify` is optional. Logged once (per
+    // config) to avoid spamming long-running processes; suppress by
+    // passing notify explicitly (true OR false counts as an explicit
+    // choice).
+    if (opts?.notify === undefined && !silentDefaultNoticed.has(this.config)) {
+      silentDefaultNoticed.add(this.config);
+      console.info(
+        '[@e4a/pg-js] sealed.upload(): notify is unset — uploading silently ' +
+        '(no recipient email sent). Pass { notify: { recipients: true } } to email ' +
+        'recipients, or { notify: { recipients: false } } to make the silent intent ' +
+        'explicit and suppress this notice.'
+      );
+    }
+
     // ReadableStream payloads can't be wrapped as a File for the upload
     // pipeline — refuse upfront rather than silently uploading zero bytes
     // and returning a UUID that points at empty ciphertext. toBytes()
@@ -154,6 +171,12 @@ export function resolveFiles(options: EncryptInput): File[] {
 const VALID_NOTIFY_KEYS = new Set(['recipients', 'sender', 'message', 'language']);
 const VALID_UPLOAD_KEYS = new Set(['notify']);
 const VALID_LANGUAGES: ReadonlySet<string> = new Set(['EN', 'NL']);
+
+/** Tracks which PostGuard configs have already seen the silent-default
+ *  notice, so a long-running process logs it once rather than on every
+ *  upload. Keyed by config object so each `new PostGuard(...)` gets one
+ *  chance to be told. */
+const silentDefaultNoticed = new WeakSet<PostGuardConfig>();
 
 /** Catches the most common upload misconfigurations early with a clear
  *  error, before they silently degrade to "no notification email sent". */

--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -159,6 +159,43 @@ describe('PostGuard', () => {
     });
   });
 
+  describe('silent-default notice', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const newPg = () =>
+      new PostGuard({
+        pkgUrl: 'https://pkg.example.com',
+        cryptifyUrl: 'https://cryptify.example.com',
+      });
+
+    const newSealed = (instance: PostGuard) =>
+      instance.encrypt({
+        files: [new File([new Uint8Array([0])], 'a.bin')],
+        recipients: [instance.recipient.email('a@b.com')],
+        sign: instance.sign.apiKey('PG-test'),
+      });
+
+    it('logs once when notify is unset on a fresh PostGuard', async () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const instance = newPg();
+      // Two uploads on the same instance — info should fire exactly once.
+      await newSealed(instance).upload().catch(() => {});
+      await newSealed(instance).upload().catch(() => {});
+      expect(info).toHaveBeenCalledTimes(1);
+      expect(info.mock.calls[0][0]).toMatch(/notify is unset — uploading silently/);
+    });
+
+    it('does not log when notify is set explicitly (true or false)', async () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const instance = newPg();
+      await newSealed(instance).upload({ notify: { recipients: true } }).catch(() => {});
+      await newSealed(newPg()).upload({ notify: { recipients: false } }).catch(() => {});
+      expect(info).not.toHaveBeenCalled();
+    });
+  });
+
   describe('resolveFiles', () => {
     const sign = pg.sign.apiKey('PG-test');
     const recipients = [pg.recipient.email('a@b.com')];


### PR DESCRIPTION
## Summary

Closes the one failure mode neither TypeScript nor `validateUploadOptions` can catch: a caller who simply forgets to set `notify` on `sealed.upload()` and silently gets no recipient email.

Since `notify` is optional in `UploadOptions`, omitting it type-checks cleanly — the user only finds out via a support ticket. The validator (#76) catches *wrong-shape* misuse but cannot catch *no shape at all*.

This commit emits a one-time `console.info` on the first `sealed.upload()` call per `PostGuard` instance where `notify` is undefined:

```
[@e4a/pg-js] sealed.upload(): notify is unset — uploading silently
(no recipient email sent). Pass { notify: { recipients: true } } to
email recipients, or { notify: { recipients: false } } to make the
silent intent explicit and suppress this notice.
```

## Behaviour

- Logged via `console.info` (informational, not a warning).
- Tracked per `PostGuard` config via `WeakSet` so long-running processes get one notice, not one per upload.
- Suppressed by passing `notify` explicitly — either `{ recipients: true }` (email) or `{ recipients: false }` (silent, but with intent). Both signal "I know what I'm doing."

## Test plan

- [x] `npm test` — 111/111 passing (2 new tests in `tests/postguard.test.ts`)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Manual: ran live smoke against staging; notice fired once, upload succeeded with real UUID