### PR TITLE
feat(sign): accept Yivi condiscon in pg.sign.yivi attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,9 @@ export type {
   UploadResult,
   // Attribute types
   AttributeCon,
+  AttrReq,
+  AttrDiscon,
+  AttrConItem,
   // Email
   BuildMimeOptions,
   CreateEnvelopeOptions,

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -4,6 +4,7 @@ import type {
   YiviSign,
   SessionSign,
   SessionCallback,
+  AttrConItem,
 } from './types.js';
 import { RecipientBuilder } from './recipients/builder.js';
 import { EmailHelpers } from './email/index.js';
@@ -27,7 +28,12 @@ export class PostGuardBase {
       type: 'apiKey',
       apiKey,
     }),
-    yivi: (opts: { element: string; senderEmail?: string; attributes?: { t: string; v?: string; optional?: boolean }[]; includeSender?: boolean }): YiviSign => ({
+    yivi: (opts: {
+      element: string;
+      senderEmail?: string;
+      attributes?: AttrConItem[];
+      includeSender?: boolean;
+    }): YiviSign => ({
       type: 'yivi',
       ...opts,
     }),

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -20,6 +20,8 @@ export function buildStartRequestBody(opts: YiviSignOptions): {
   const emailAttr: AttrReq = opts.senderEmail
     ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
     : { t: 'pbdf.sidn-pbdf.email.email' };
+  // Callers must not include pbdf.sidn-pbdf.email.email in `attributes`; it
+  // is always prepended automatically and would appear twice otherwise.
   return { con: [emailAttr, ...(opts.attributes ?? [])] };
 }
 

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -3,13 +3,24 @@ import { YiviClient } from '@privacybydesign/yivi-client';
 import { YiviWeb } from '@privacybydesign/yivi-web';
 import { injectYiviCss } from '../yivi/inject-css.js';
 import { YiviSessionError } from '../errors.js';
-import type { SigningKeys } from '../types.js';
+import type { SigningKeys, AttrConItem, AttrReq } from '../types.js';
 
 export interface YiviSignOptions {
   element: string;
   senderEmail?: string;
-  attributes?: { t: string; v?: string; optional?: boolean }[];
+  attributes?: AttrConItem[];
   includeSender?: boolean;
+}
+
+/** Build the JSON body POSTed to `${pkgUrl}/v2/request/start`.
+ *  Exposed for unit testing — the runtime call path uses it via `JSON.stringify`. */
+export function buildStartRequestBody(opts: YiviSignOptions): {
+  con: AttrConItem[];
+} {
+  const emailAttr: AttrReq = opts.senderEmail
+    ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
+    : { t: 'pbdf.sidn-pbdf.email.email' };
+  return { con: [emailAttr, ...(opts.attributes ?? [])] };
 }
 
 /**
@@ -65,14 +76,7 @@ export async function resolveSigningKeysFromYivi(
         'Content-Type': 'application/json',
         ...extraHeaders,
       },
-      body: JSON.stringify({
-        con: [
-          opts.senderEmail
-            ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
-            : { t: 'pbdf.sidn-pbdf.email.email' },
-          ...(opts.attributes ?? []),
-        ],
-      }),
+      body: JSON.stringify(buildStartRequestBody(opts)),
     },
     result: {
       url: (o: any, { sessionToken }: any) => `${o.url}/v2/request/jwt/${sessionToken}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,14 +33,32 @@ export interface ApiKeySign {
   apiKey: string;
 }
 
+/** A single attribute in a disclosure request. */
+export type AttrReq = { t: string; v?: string; optional?: boolean };
+
+/** A disjunction-of-conjunctions: each inner array is one alternative
+ *  conjunction the user can satisfy. An empty inner array marks the
+ *  whole discon as optional, per Yivi convention. */
+export type AttrDiscon = AttrReq[][];
+
+/** One entry in the top-level Yivi disclosure request:
+ *  either a single attribute or a disjunction-of-conjunctions. */
+export type AttrConItem = AttrReq | AttrDiscon;
+
 /** Signing via Yivi session (peer-to-peer) */
 export interface YiviSign {
   type: 'yivi';
   element: string;
   senderEmail?: string;
   /** Additional attributes to request in the Yivi session (e.g. name).
-   *  Email is always included automatically. Mark as optional to let the user skip. */
-  attributes?: { t: string; v?: string; optional?: boolean }[];
+   *  Email is always included automatically.
+   *
+   *  Each entry is either a single attribute (legacy flat shape — mark
+   *  `optional: true` to let the user skip it) or a Yivi
+   *  disjunction-of-conjunctions: a `AttrReq[][]` where each inner array
+   *  is one alternative conjunction. Inside a discon, use an empty inner
+   *  array to mark the whole discon optional. */
+  attributes?: AttrConItem[];
   includeSender?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,8 @@ export type AttrReq = { t: string; v?: string; optional?: boolean };
 export type AttrDiscon = AttrReq[][];
 
 /** One entry in the top-level Yivi disclosure request:
- *  either a single attribute or a disjunction-of-conjunctions. */
+ *  either a single attribute or a disjunction-of-conjunctions.
+ *  Narrow with `Array.isArray(item)`: true → `AttrDiscon`, false → `AttrReq`. */
 export type AttrConItem = AttrReq | AttrDiscon;
 
 /** Signing via Yivi session (peer-to-peer) */

--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { PostGuard } from '../src/postguard.js';
 import { RecipientBuilder } from '../src/recipients/builder.js';
 import { resolveFiles } from '../src/sealed.js';
-import { resolveSigningKeysFromYivi } from '../src/signing/yivi.js';
+import {
+  resolveSigningKeysFromYivi,
+  buildStartRequestBody,
+} from '../src/signing/yivi.js';
 import { YiviSessionError } from '../src/errors.js';
 
 describe('PostGuard', () => {
@@ -34,6 +37,67 @@ describe('PostGuard', () => {
     it('builds yivi sign method without optional includeSender', () => {
       const sign = pg.sign.yivi({ element: '#yivi', senderEmail: 'a@b.com' });
       expect(sign.includeSender).toBeUndefined();
+    });
+  });
+
+  describe('buildStartRequestBody', () => {
+    it('prepends the email attribute (unbound) when no senderEmail given', () => {
+      const body = buildStartRequestBody({ element: '#yivi' });
+      expect(body).toEqual({ con: [{ t: 'pbdf.sidn-pbdf.email.email' }] });
+    });
+
+    it('binds the email attribute when senderEmail is given', () => {
+      const body = buildStartRequestBody({
+        element: '#yivi',
+        senderEmail: 'sender@example.com',
+      });
+      expect(body).toEqual({
+        con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'sender@example.com' }],
+      });
+    });
+
+    it('preserves legacy flat attribute entries with optional flag', () => {
+      const body = buildStartRequestBody({
+        element: '#yivi',
+        attributes: [
+          { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', optional: true },
+        ],
+      });
+      expect(body).toEqual({
+        con: [
+          { t: 'pbdf.sidn-pbdf.email.email' },
+          { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', optional: true },
+        ],
+      });
+    });
+
+    it('passes through a disjunction-of-conjunctions entry as a nested array', () => {
+      const body = buildStartRequestBody({
+        element: '#yivi',
+        attributes: [
+          [
+            [{ t: 'pbdf.gemeente.personalData.fullname' }],
+            [
+              { t: 'pbdf.pbdf.passport.firstName' },
+              { t: 'pbdf.pbdf.passport.lastName' },
+            ],
+          ],
+          { t: 'pbdf.gemeente.personalData.dateofbirth', optional: true },
+        ],
+      });
+      expect(body).toEqual({
+        con: [
+          { t: 'pbdf.sidn-pbdf.email.email' },
+          [
+            [{ t: 'pbdf.gemeente.personalData.fullname' }],
+            [
+              { t: 'pbdf.pbdf.passport.firstName' },
+              { t: 'pbdf.pbdf.passport.lastName' },
+            ],
+          ],
+          { t: 'pbdf.gemeente.personalData.dateofbirth', optional: true },
+        ],
+      });
     });
   });
 

--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -99,6 +99,22 @@ describe('PostGuard', () => {
         ],
       });
     });
+
+    it('preserves empty inner array marking an optional discon', () => {
+      // Per Yivi convention, [[],  [{t: '...'}]] means the discon is optional
+      // (the empty alternative is always satisfiable). The empty array must
+      // survive the spread unchanged.
+      const body = buildStartRequestBody({
+        element: '#yivi',
+        attributes: [[[], [{ t: 'pbdf.gemeente.personalData.fullname' }]]],
+      });
+      expect(body).toEqual({
+        con: [
+          { t: 'pbdf.sidn-pbdf.email.email' },
+          [[], [{ t: 'pbdf.gemeente.personalData.fullname' }]],
+        ],
+      });
+    });
   });
 
   describe('recipient builders', () => {


### PR DESCRIPTION
## Summary

- `src/types.ts`: new exported types `AttrReq` / `AttrDiscon` / `AttrConItem`; widen `YiviSign.attributes` from `AttrReq[]` to `AttrConItem[]`.
- `src/signing/yivi.ts`: extract `buildStartRequestBody` so the JSON body sent to `${pkgUrl}/v2/request/start` is built by a pure, unit-tested function.
- `src/index.ts`: re-export the new attribute types.
- `src/postguard-base.ts`: align the `pg.sign.yivi(opts)` inline opts type.

Backwards compatible: existing callers that pass `{t,v?,optional?}` objects continue to work without changes — this is a minor, additive bump. New callers can mix Singles and Discons freely; an empty inner array marks the discon optional, per Yivi convention.

## Why

postguard-website needs to ask for a sender name from one of four Yivi credentials (gemeente fullname OR `firstName`+`lastName` from passport / idcard / drivinglicence). That's a Yivi disjunction-of-conjunctions, which the previous flat `AttrReq[]` shape could not express. The matching PKG change is in `encryption4all/postguard#198`.

## Test plan

- [x] `npm test` — 115/115 (4 new `buildStartRequestBody` cases + 111 prior).
- [x] `npm run typecheck` clean.
- [x] `npm run build` ✓ — `dist/` regenerated.
- [ ] Smoke once published: bump in postguard-website and exercise the Yivi sign flow end-to-end.

## Companion PRs

- `postguard` (PKG): `encryption4all/postguard#198`
- `cryptify`: forthcoming
- `postguard-website`: forthcoming (supersedes #239 there)