### PR TITLE
ci: enable npm cache in setup-node to speed up Integration / Delivery

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -30,6 +30,7 @@ jobs:
               with:
                   node-version: '24'
                   registry-url: 'https://registry.npmjs.org'
+                  cache: 'npm'
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node }}
+                  cache: 'npm'
 
             - name: Install dependencies
               run: npm ci
@@ -52,6 +53,7 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: '22'
+                  cache: 'npm'
 
             - name: Setup Bun
               uses: oven-sh/setup-bun@v2
@@ -85,6 +87,7 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: '22'
+                  cache: 'npm'
 
             - name: Setup Deno
               uses: denoland/setup-deno@v2


### PR DESCRIPTION
## Summary

- Adds `cache: 'npm'` to all `actions/setup-node@v6` steps in `integration.yml` (Node, Bun, and Deno jobs) and `delivery.yml` (Release job)
- Preserves the existing `registry-url` line in `delivery.yml`

Closes #60