### PR TITLE
feat(decrypt): onDownloadProgress callback + auto-unzip files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pretest": "node scripts/generate-wasm-base64.mjs && node scripts/generate-yivi-css.mjs",
     "pretest:watch": "node scripts/generate-wasm-base64.mjs && node scripts/generate-yivi-css.mjs",
     "build": "tsdown",
+    "prepare": "node scripts/generate-wasm-base64.mjs && node scripts/generate-yivi-css.mjs && tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/api/cryptify.ts
+++ b/src/api/cryptify.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedRetryOptions,
   type RetryOptions,
 } from '../util/retry.js';
+import { ProgressPipe } from '../util/progress.js';
 
 export interface FileState {
   /** Current rolling token — what the next chunk PUT should send. */
@@ -272,12 +273,15 @@ export async function finalizeUpload(
   }
 }
 
-/** Download an encrypted file as a ReadableStream */
+/** Download an encrypted file as a ReadableStream. Returns the total
+ *  byte count from `Content-Length` when the server advertises it
+ *  (cryptify does for `GET /filedownload/{uuid}` without Range); callers
+ *  use this to drive progress reporting. */
 export async function downloadFile(
   cryptifyUrl: string,
   uuid: string,
   signal?: AbortSignal
-): Promise<ReadableStream<Uint8Array>> {
+): Promise<{ stream: ReadableStream<Uint8Array>; totalBytes: number | undefined }> {
   const response = await fetch(`${cryptifyUrl}/filedownload/${uuid}`, {
     signal,
     method: 'GET',
@@ -289,7 +293,12 @@ export async function downloadFile(
   }
 
   if (!response.body) throw new Error('Response body is null');
-  return response.body as ReadableStream<Uint8Array>;
+
+  const cl = response.headers?.get('content-length') ?? null;
+  const n = cl ? Number.parseInt(cl, 10) : NaN;
+  const totalBytes = Number.isFinite(n) && n > 0 ? n : undefined;
+
+  return { stream: response.body as ReadableStream<Uint8Array>, totalBytes };
 }
 
 /**
@@ -375,11 +384,12 @@ export function downloadFileWithRetry(
   uuid: string,
   retry: ResolvedRetryOptions,
   signal?: AbortSignal
-): ReadableStream<Uint8Array> {
+): { stream: ReadableStream<Uint8Array>; pipe: ProgressPipe } {
   let received = 0;
   let attempt = 0;
+  const pipe = new ProgressPipe();
 
-  return new ReadableStream<Uint8Array>({
+  const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       // Single source of truth: each underlying GET is one `attempt`,
       // counter is shared across resumes so a flapping connection that
@@ -388,13 +398,17 @@ export function downloadFileWithRetry(
         attempt += 1;
         const { signal: timed, cleanup } = withTimeout(signal, retry.downloadTimeoutMs);
         try {
-          const stream =
-            received === 0
-              ? await downloadFile(cryptifyUrl, uuid, timed)
-              : await downloadRange(cryptifyUrl, uuid, received, timed);
+          let innerStream: ReadableStream<Uint8Array>;
+          if (received === 0) {
+            const { stream: s, totalBytes } = await downloadFile(cryptifyUrl, uuid, timed);
+            pipe.setTotal(totalBytes);
+            innerStream = s;
+          } else {
+            innerStream = await downloadRange(cryptifyUrl, uuid, received, timed);
+          }
           cleanup();
 
-          const reader = stream.getReader();
+          const reader = innerStream.getReader();
           for (;;) {
             const { value, done } = await reader.read();
             if (done) {
@@ -402,6 +416,7 @@ export function downloadFileWithRetry(
               return;
             }
             received += value.byteLength;
+            pipe.report(received);
             controller.enqueue(value);
           }
         } catch (err) {
@@ -445,6 +460,8 @@ export function downloadFileWithRetry(
       void reason;
     },
   });
+
+  return { stream, pipe };
 }
 
 export interface UploadStream {

--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -6,10 +6,11 @@ import { downloadFile, downloadFileWithRetry } from '../api/cryptify.js';
 import { resolveRetryOptions, type RetryOptions } from '../util/retry.js';
 import { buildKeyRequest } from '../util/policy.js';
 import { retrieveUSKViaYivi } from '../yivi/decrypt-session.js';
-import { readZipFilenames } from '../util/zip.js';
-import { triggerBrowserDownload } from '../util/download.js';
+import { extractAllZipEntries } from '../util/zip.js';
+import { triggerBrowserDownloads } from '../util/download.js';
 import { loadWasm } from '../util/wasm.js';
 import { parseSender } from '../util/identity.js';
+import { ProgressPipe } from '../util/progress.js';
 
 // --- Inspect (shared by Opened and legacy functions) ---
 
@@ -27,6 +28,11 @@ export interface InspectSealedResult {
   unsealer: any;
   policies: Map<string, any>;
   sender: SenderIdentity | null;
+  /** Progress tracker for the underlying download stream. Null when
+   *  decrypting from raw data (no network involved). Callers attach
+   *  their progress callback via `pipe.setCallback()` before consuming
+   *  the stream. */
+  pipe: ProgressPipe | null;
 }
 
 /** Inspect a sealed file/data without decrypting. Returns unsealer + metadata. */
@@ -36,16 +42,22 @@ export async function inspectSealed(options: InspectSealedOptions): Promise<Insp
   // Get the readable stream (either from Cryptify or raw data)
   let readable: ReadableStream<Uint8Array>;
   let vkPromise: Promise<unknown>;
+  let pipe: ProgressPipe | null = null;
 
   if (uuid && cryptifyUrl) {
-    // Download from Cryptify and fetch VK in parallel
+    // Kick off VK fetch and download stream setup in parallel. The
+    // ReadableStream returned by downloadFileWithRetry is lazy — the
+    // first HTTP GET happens when the stream is read, not here.
     const retry = resolveRetryOptions(options.retry);
-    const [vk, fileStream] = await Promise.all([
-      fetchVerificationKey(pkgUrl, headers),
-      downloadFileWithRetry(cryptifyUrl, uuid, retry, signal),
-    ]);
+    vkPromise = fetchVerificationKey(pkgUrl, headers);
+    const { stream: fileStream, pipe: streamPipe } = downloadFileWithRetry(
+      cryptifyUrl,
+      uuid,
+      retry,
+      signal,
+    );
     readable = fileStream;
-    vkPromise = Promise.resolve(vk);
+    pipe = streamPipe;
   } else if (data) {
     readable = data instanceof ReadableStream
       ? data
@@ -73,7 +85,7 @@ export async function inspectSealed(options: InspectSealedOptions): Promise<Insp
     // May not be available before unsealing
   }
 
-  return { unsealer, policies, sender };
+  return { unsealer, policies, sender, pipe };
 }
 
 // --- Unseal helpers (shared by Opened and legacy functions) ---
@@ -186,14 +198,13 @@ export async function decryptFromUuid(options: DecryptFromUuidOptions): Promise<
 
   const { chunks, sender } = await unsealAndCollect(unsealer, key, usk, preUnsealSender);
 
-  const blob = new Blob(chunks as BlobPart[], { type: 'application/zip' });
-  const files = await readZipFilenames(blob);
+  const zipBlob = new Blob(chunks as BlobPart[], { type: 'application/zip' });
+  const extractedFiles = await extractAllZipEntries(zipBlob);
 
   return {
-    files,
+    files: extractedFiles,
     sender: parseSender(sender),
-    blob,
-    download: (filename = 'files.zip') => triggerBrowserDownload(blob, filename),
+    download: () => triggerBrowserDownloads(extractedFiles),
   };
 }
 

--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -203,6 +203,7 @@ export async function decryptFromUuid(options: DecryptFromUuidOptions): Promise<
 
   return {
     files: extractedFiles,
+    blob: zipBlob,
     sender: parseSender(sender),
     download: () => triggerBrowserDownloads(extractedFiles),
   };

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -14,15 +14,17 @@ import {
   resolveUSK,
   unsealAndCollect,
 } from './crypto/decrypt.js';
-import { readZipFilenames, extractZipEntry } from './util/zip.js';
-import { triggerBrowserDownload } from './util/download.js';
+import { extractAllZipEntries } from './util/zip.js';
+import { triggerBrowserDownloads } from './util/download.js';
 import { parseSender } from './util/identity.js';
+import { ProgressPipe } from './util/progress.js';
 
 /** Lazy decryption builder. Supports inspect-before-decrypt pattern. */
 export class Opened {
   private unsealer: any = null;
   private cachedPolicies: Map<string, any> | null = null;
   private cachedSender: SenderIdentity | null = null;
+  private progressPipe: ProgressPipe | null = null;
 
   /** @internal */
   constructor(
@@ -44,7 +46,7 @@ export class Opened {
 
     const isUuid = 'uuid' in this.options;
 
-    const { unsealer, policies, sender } = await inspectSealed({
+    const { unsealer, policies, sender, pipe } = await inspectSealed({
       pkgUrl: this.config.pkgUrl,
       cryptifyUrl: isUuid ? this.config.cryptifyUrl : undefined,
       uuid: isUuid ? this.options.uuid : undefined,
@@ -57,6 +59,7 @@ export class Opened {
     this.unsealer = unsealer;
     this.cachedPolicies = policies;
     this.cachedSender = sender;
+    this.progressPipe = pipe;
 
     return {
       recipients: [...policies.keys()],
@@ -87,6 +90,14 @@ export class Opened {
       opts.enableCache,
     );
 
+    // Attach progress callback just before we drain the stream: bytes
+    // flow during unsealAndCollect, which is the next call. Set here
+    // (not at construction time) so callers can supply onDownloadProgress
+    // via DecryptInput rather than the PostGuard config.
+    if (opts.onDownloadProgress) {
+      this.progressPipe?.setCallback(opts.onDownloadProgress);
+    }
+
     const { chunks, sender } = await unsealAndCollect(
       this.unsealer,
       key,
@@ -97,15 +108,14 @@ export class Opened {
     const isUuid = 'uuid' in this.options;
 
     if (isUuid) {
-      // UUID-based: return files from ZIP
-      const blob = new Blob(chunks as BlobPart[], { type: 'application/zip' });
-      const files = await readZipFilenames(blob);
+      const zipBlob = new Blob(chunks as BlobPart[], { type: 'application/zip' });
+      const extractedFiles = await extractAllZipEntries(zipBlob);
 
       // Symmetry with Sealed.upload's data: mode: it wraps raw bytes as a
       // single-entry zip with `data.bin`. Unwrap here so the round-trip
       // matches pg.encrypt({ data }) → pg.open({ uuid }).decrypt().
-      if (files.length === 1 && files[0] === 'data.bin') {
-        const plaintext = await extractZipEntry(blob, 'data.bin');
+      if (extractedFiles.length === 1 && extractedFiles[0].name === 'data.bin') {
+        const plaintext = new Uint8Array(await extractedFiles[0].blob.arrayBuffer());
         return {
           plaintext,
           sender: parseSender(sender),
@@ -113,10 +123,9 @@ export class Opened {
       }
 
       return {
-        files,
+        files: extractedFiles,
         sender: parseSender(sender),
-        blob,
-        download: (filename = 'files.zip') => triggerBrowserDownload(blob, filename),
+        download: () => triggerBrowserDownloads(extractedFiles),
       } as DecryptFileResult;
     }
 

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -124,9 +124,10 @@ export class Opened {
 
       return {
         files: extractedFiles,
+        blob: zipBlob,
         sender: parseSender(sender),
         download: () => triggerBrowserDownloads(extractedFiles),
-      } as DecryptFileResult;
+      };
     }
 
     // Data-based: return plaintext bytes

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,9 +170,13 @@ export interface InspectResult {
 
 /** Result of decrypting files (from UUID). Files are auto-extracted
  *  from the inner ZIP; `download()` triggers one browser download per
- *  entry. */
+ *  entry. `blob` is the raw ZIP archive — kept as an escape hatch for
+ *  callers that want to re-upload, hand-process, or offer a single
+ *  "Download as ZIP" button instead of the per-file fan-out (some
+ *  browsers prompt for multi-file downloads). */
 export interface DecryptFileResult {
   files: Array<{ name: string; blob: Blob }>;
+  blob: Blob;
   sender: FriendlySender | null;
   download: () => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,12 @@ export interface DecryptInput {
   recipient?: string;
   /** Enable JWT caching to avoid re-scanning QR for repeated decryptions */
   enableCache?: boolean;
+  /** Progress callback for the download+decrypt streaming pipeline.
+   *  Receives `0–100` when the server advertised `Content-Length`, or
+   *  `undefined` when it didn't (consumer should render an
+   *  indeterminate progress indicator). Fires on every chunk so callers
+   *  can detect that bytes have started flowing regardless of mode. */
+  onDownloadProgress?: (percentage: number | undefined) => void;
 }
 
 // --- Results ---
@@ -162,12 +168,13 @@ export interface InspectResult {
   policies: Map<string, any>;
 }
 
-/** Result of decrypting files (from UUID) */
+/** Result of decrypting files (from UUID). Files are auto-extracted
+ *  from the inner ZIP; `download()` triggers one browser download per
+ *  entry. */
 export interface DecryptFileResult {
-  files: string[];
+  files: Array<{ name: string; blob: Blob }>;
   sender: FriendlySender | null;
-  blob: Blob;
-  download: (filename?: string) => void;
+  download: () => void;
 }
 
 /** Result of decrypting raw data */

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -9,3 +9,10 @@ export function triggerBrowserDownload(blob: Blob, filename: string): void {
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 }
+
+/** Trigger a browser download for each file in the list */
+export function triggerBrowserDownloads(files: Array<{ name: string; blob: Blob }>): void {
+  for (const { name, blob } of files) {
+    triggerBrowserDownload(blob, name);
+  }
+}

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -1,16 +1,39 @@
-/** Trigger a browser file download from a Blob */
+/** Strip directory components from a ZIP entry name. ZIP archives can
+ *  legally carry names like `../../etc/passwd` or absolute paths; left
+ *  unfiltered these flow straight to `<a download>` whose browser
+ *  sanitization is inconsistent. Take the basename after the last
+ *  forward or back slash; fall back to a placeholder if nothing
+ *  remains (e.g. the entry was just `/`).
+ *
+ *  This is for browser-trigger UX, not arbitrary-path defense — the
+ *  `<a download>` attribute is already a hint, and a malicious archive
+ *  can still trip on `name === ''` if we don't substitute. */
+export function sanitizeDownloadFilename(name: string): string {
+  const basename = name.replace(/^.*[/\\]/, '');
+  return basename || 'file';
+}
+
+/** Trigger a browser file download from a Blob. The filename is
+ *  sanitized to its basename to avoid path-traversal-style ZIP names
+ *  reaching the user's filesystem hints. */
 export function triggerBrowserDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = filename;
+  a.download = sanitizeDownloadFilename(filename);
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 }
 
-/** Trigger a browser download for each file in the list */
+/** Trigger a browser download for each file in the list.
+ *
+ *  Caveat: triggering multiple downloads from a single user gesture
+ *  prompts the user in Firefox/Safari, and Chrome shows a
+ *  "wants to download multiple files" bar. For a single "Download
+ *  everything as one ZIP" experience, callers should use
+ *  `DecryptFileResult.blob` directly with `triggerBrowserDownload`. */
 export function triggerBrowserDownloads(files: Array<{ name: string; blob: Blob }>): void {
   for (const { name, blob } of files) {
     triggerBrowserDownload(blob, name);

--- a/src/util/progress.ts
+++ b/src/util/progress.ts
@@ -1,0 +1,30 @@
+/** Mutable-callback progress tracker for streaming downloads.
+ *  Created before the download stream starts; callback and total can be
+ *  attached later (e.g. when decrypt() is called).
+ *
+ *  When `total` is known (server sent Content-Length), the callback
+ *  receives 0–100. When `total` is unknown, it still fires on every
+ *  chunk with `undefined` so consumers can detect "stream has started,
+ *  show indeterminate progress" — otherwise the UI would have no way
+ *  to leave its pre-download state. */
+export class ProgressPipe {
+  private cb?: (pct: number | undefined) => void;
+  private total?: number;
+
+  setTotal(total: number | undefined): void {
+    this.total = total;
+  }
+
+  setCallback(cb: (pct: number | undefined) => void): void {
+    this.cb = cb;
+  }
+
+  report(received: number): void {
+    if (!this.cb) return;
+    if (this.total) {
+      this.cb(Math.min(100, Math.round((received / this.total) * 100)));
+    } else {
+      this.cb(undefined);
+    }
+  }
+}

--- a/src/util/progress.ts
+++ b/src/util/progress.ts
@@ -6,10 +6,17 @@
  *  receives 0–100. When `total` is unknown, it still fires on every
  *  chunk with `undefined` so consumers can detect "stream has started,
  *  show indeterminate progress" — otherwise the UI would have no way
- *  to leave its pre-download state. */
+ *  to leave its pre-download state.
+ *
+ *  State is buffered: if bytes flow before `setCallback` is called
+ *  (e.g. a very small payload where `inspect()` drains the whole
+ *  stream during header parsing), attaching the callback later replays
+ *  the latest state so consumers still get at least one event. */
 export class ProgressPipe {
   private cb?: (pct: number | undefined) => void;
   private total?: number;
+  private received = 0;
+  private hasReported = false;
 
   setTotal(total: number | undefined): void {
     this.total = total;
@@ -17,12 +24,19 @@ export class ProgressPipe {
 
   setCallback(cb: (pct: number | undefined) => void): void {
     this.cb = cb;
+    if (this.hasReported) this.emit();
   }
 
   report(received: number): void {
+    this.received = received;
+    this.hasReported = true;
+    this.emit();
+  }
+
+  private emit(): void {
     if (!this.cb) return;
     if (this.total) {
-      this.cb(Math.min(100, Math.round((received / this.total) * 100)));
+      this.cb(Math.min(100, Math.round((this.received / this.total) * 100)));
     } else {
       this.cb(undefined);
     }

--- a/src/util/zip.ts
+++ b/src/util/zip.ts
@@ -123,39 +123,68 @@ export async function extractZipEntry(blob: Blob, name: string): Promise<Uint8Ar
   throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
 }
 
+/** Max concurrent deflate decompressions. Each in-flight entry holds
+ *  both its compressed slice and its inflated output in memory; an
+ *  unbounded `Promise.all` over a multi-file archive can spike peak
+ *  memory well past the archive size. Four is a small cap that still
+ *  parallelises across cores for the common case. */
+const EXTRACT_CONCURRENCY = 4;
+
 /** Extract all entries from a ZIP blob, returning each as a named Blob.
  *  Directory entries (names ending with '/') are skipped. Supports method
  *  0 (stored) and method 8 (deflate). Reads the underlying buffer once
- *  and unpacks each entry from it. */
+ *  and unpacks each entry from it. Concurrency is capped (see
+ *  EXTRACT_CONCURRENCY) so peak memory scales with the cap, not the
+ *  number of entries. */
 export async function extractAllZipEntries(blob: Blob): Promise<Array<{ name: string; blob: Blob }>> {
   const buf = await blob.arrayBuffer();
   const view = new DataView(buf);
   const bytes = new Uint8Array(buf);
   const entries = readCentralDirectory(view, bytes).filter((e) => !e.name.endsWith('/'));
 
-  return Promise.all(
-    entries.map(async (entry) => {
-      const lfh = entry.lfhOffset;
-      if (view.getUint32(lfh, true) !== 0x04034b50) {
-        throw new Error(`Invalid local file header at offset ${lfh}`);
-      }
-      const lfhFilenameLen = view.getUint16(lfh + 26, true);
-      const lfhExtraLen = view.getUint16(lfh + 28, true);
-      const dataStart = lfh + 30 + lfhFilenameLen + lfhExtraLen;
-      const compressed = bytes.slice(dataStart, dataStart + entry.compressedSize);
+  async function extractOne(entry: typeof entries[number]): Promise<{ name: string; blob: Blob }> {
+    const lfh = entry.lfhOffset;
+    if (view.getUint32(lfh, true) !== 0x04034b50) {
+      throw new Error(`Invalid local file header at offset ${lfh}`);
+    }
+    const lfhFilenameLen = view.getUint16(lfh + 26, true);
+    const lfhExtraLen = view.getUint16(lfh + 28, true);
+    const dataStart = lfh + 30 + lfhFilenameLen + lfhExtraLen;
+    const compressed = bytes.slice(dataStart, dataStart + entry.compressedSize);
 
-      let data: Uint8Array;
-      if (entry.method === 0) {
-        data = compressed;
-      } else if (entry.method === 8) {
-        const ds = new DecompressionStream('deflate-raw');
-        const stream = new Blob([compressed as BlobPart]).stream().pipeThrough(ds);
-        data = new Uint8Array(await new Response(stream).arrayBuffer());
-      } else {
-        throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
-      }
+    let data: Uint8Array;
+    if (entry.method === 0) {
+      data = compressed;
+    } else if (entry.method === 8) {
+      const ds = new DecompressionStream('deflate-raw');
+      const stream = new Blob([compressed]).stream().pipeThrough(ds);
+      data = new Uint8Array(await new Response(stream).arrayBuffer());
+    } else {
+      throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
+    }
 
-      return { name: entry.name, blob: new Blob([data as BlobPart]) };
+    // `data` from `arrayBuffer()` carries `Uint8Array<ArrayBufferLike>`,
+    // which TS won't unify with `BlobPart` (ArrayBufferLike could be a
+    // SharedArrayBuffer). The cast is sound — it can't be shared because
+    // we just allocated it from a Response body.
+    return { name: entry.name, blob: new Blob([data as BlobPart]) };
+  }
+
+  // Bounded worker pool: each worker pulls the next index off a shared
+  // counter, so any worker that finishes early picks up the next entry
+  // rather than waiting for its sibling slots. Preserves input order in
+  // the result array.
+  const results: Array<{ name: string; blob: Blob }> = new Array(entries.length);
+  let cursor = 0;
+  const workerCount = Math.min(EXTRACT_CONCURRENCY, entries.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= entries.length) return;
+        results[i] = await extractOne(entries[i]);
+      }
     }),
   );
+  return results;
 }

--- a/src/util/zip.ts
+++ b/src/util/zip.ts
@@ -122,3 +122,40 @@ export async function extractZipEntry(blob: Blob, name: string): Promise<Uint8Ar
   }
   throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
 }
+
+/** Extract all entries from a ZIP blob, returning each as a named Blob.
+ *  Directory entries (names ending with '/') are skipped. Supports method
+ *  0 (stored) and method 8 (deflate). Reads the underlying buffer once
+ *  and unpacks each entry from it. */
+export async function extractAllZipEntries(blob: Blob): Promise<Array<{ name: string; blob: Blob }>> {
+  const buf = await blob.arrayBuffer();
+  const view = new DataView(buf);
+  const bytes = new Uint8Array(buf);
+  const entries = readCentralDirectory(view, bytes).filter((e) => !e.name.endsWith('/'));
+
+  return Promise.all(
+    entries.map(async (entry) => {
+      const lfh = entry.lfhOffset;
+      if (view.getUint32(lfh, true) !== 0x04034b50) {
+        throw new Error(`Invalid local file header at offset ${lfh}`);
+      }
+      const lfhFilenameLen = view.getUint16(lfh + 26, true);
+      const lfhExtraLen = view.getUint16(lfh + 28, true);
+      const dataStart = lfh + 30 + lfhFilenameLen + lfhExtraLen;
+      const compressed = bytes.slice(dataStart, dataStart + entry.compressedSize);
+
+      let data: Uint8Array;
+      if (entry.method === 0) {
+        data = compressed;
+      } else if (entry.method === 8) {
+        const ds = new DecompressionStream('deflate-raw');
+        const stream = new Blob([compressed as BlobPart]).stream().pipeThrough(ds);
+        data = new Uint8Array(await new Response(stream).arrayBuffer());
+      } else {
+        throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
+      }
+
+      return { name: entry.name, blob: new Blob([data as BlobPart]) };
+    }),
+  );
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -663,6 +663,58 @@ describe('Cryptify API', () => {
       expect(result.totalBytes).toBeUndefined();
     });
 
+    it('returns totalBytes from a numeric Content-Length', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: new ReadableStream(),
+        headers: new Headers({ 'content-length': '12345' }),
+      });
+
+      const result = await downloadFile('https://cryptify.example.com', 'uuid');
+      expect(result.totalBytes).toBe(12345);
+    });
+
+    it('treats Content-Length: 0 as unknown (no progress denominator)', async () => {
+      // A zero-byte body could be a legitimate response, but the
+      // resulting progress percentage (n / 0) is meaningless. The
+      // > 0 filter pushes consumers onto the indeterminate path
+      // instead of dividing by zero.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: new ReadableStream(),
+        headers: new Headers({ 'content-length': '0' }),
+      });
+
+      const result = await downloadFile('https://cryptify.example.com', 'uuid');
+      expect(result.totalBytes).toBeUndefined();
+    });
+
+    it('treats a non-numeric Content-Length as unknown', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: new ReadableStream(),
+        headers: new Headers({ 'content-length': 'banana' }),
+      });
+
+      const result = await downloadFile('https://cryptify.example.com', 'uuid');
+      expect(result.totalBytes).toBeUndefined();
+    });
+
+    it('treats a missing Content-Length as unknown', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: new ReadableStream(),
+        headers: new Headers(),
+      });
+
+      const result = await downloadFile('https://cryptify.example.com', 'uuid');
+      expect(result.totalBytes).toBeUndefined();
+    });
+
     it('throws NetworkError on failure', async () => {
       mockFetch.mockResolvedValueOnce(errorResponse(404, 'Not Found'));
       await expect(

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -659,7 +659,8 @@ describe('Cryptify API', () => {
       });
 
       const result = await downloadFile('https://cryptify.example.com', 'file-uuid');
-      expect(result).toBe(stream);
+      expect(result.stream).toBe(stream);
+      expect(result.totalBytes).toBeUndefined();
     });
 
     it('throws NetworkError on failure', async () => {
@@ -745,7 +746,7 @@ describe('Cryptify API', () => {
         body: streamOf(new Uint8Array([1, 2, 3, 4])),
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const bytes = await drain(stream);
 
       expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
@@ -772,7 +773,7 @@ describe('Cryptify API', () => {
           body: streamOf(new Uint8Array([42])),
         });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const bytes = await drain(stream);
 
       expect(Array.from(bytes)).toEqual([42]);
@@ -800,7 +801,7 @@ describe('Cryptify API', () => {
         text: () => Promise.resolve(''),
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const bytes = await drain(stream);
 
       expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -828,7 +829,7 @@ describe('Cryptify API', () => {
         text: () => Promise.resolve(''),
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
 
       const reader = stream.getReader();
       const first = await reader.read();
@@ -854,7 +855,7 @@ describe('Cryptify API', () => {
         text: () => Promise.resolve(''),
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const reader = stream.getReader();
       await reader.read(); // [1,2]
       await expect(reader.read()).rejects.toMatchObject({
@@ -871,7 +872,7 @@ describe('Cryptify API', () => {
         headers: new Headers(),
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const reader = stream.getReader();
       await expect(reader.read()).rejects.toMatchObject({
         name: 'NetworkError',
@@ -941,7 +942,7 @@ describe('Cryptify API', () => {
         });
       });
 
-      const stream = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
+      const { stream } = downloadFileWithRetry('https://cryptify.example.com', 'uuid', fastRetry);
       const reader = stream.getReader();
       // Each attempt delivers one byte before erroring. With maxAttempts=3,
       // we should see 3 bytes total, then the next read errors.
@@ -961,7 +962,7 @@ describe('Cryptify API', () => {
       controller.abort();
       mockFetch.mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
 
-      const stream = downloadFileWithRetry(
+      const { stream } = downloadFileWithRetry(
         'https://cryptify.example.com',
         'uuid',
         fastRetry,

--- a/tests/download.test.ts
+++ b/tests/download.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeDownloadFilename } from '../src/util/download.js';
+
+describe('sanitizeDownloadFilename', () => {
+  it('returns a plain basename unchanged', () => {
+    expect(sanitizeDownloadFilename('report.pdf')).toBe('report.pdf');
+  });
+
+  it('strips forward-slash directory prefixes', () => {
+    expect(sanitizeDownloadFilename('dir/sub/report.pdf')).toBe('report.pdf');
+  });
+
+  it('strips backslash directory prefixes (Windows-style paths)', () => {
+    expect(sanitizeDownloadFilename('dir\\sub\\report.pdf')).toBe('report.pdf');
+  });
+
+  it('strips mixed separators by taking the last component after either', () => {
+    expect(sanitizeDownloadFilename('a/b\\c/report.pdf')).toBe('report.pdf');
+    expect(sanitizeDownloadFilename('a\\b/c\\report.pdf')).toBe('report.pdf');
+  });
+
+  it('neutralises path-traversal style names', () => {
+    // ZIP archives can legally carry `../../foo`; without basename
+    // stripping these would land in `<a download>` and rely on the
+    // browser to sanitize.
+    expect(sanitizeDownloadFilename('../../etc/passwd')).toBe('passwd');
+    expect(sanitizeDownloadFilename('/etc/passwd')).toBe('passwd');
+  });
+
+  it('falls back to "file" when only separators remain', () => {
+    expect(sanitizeDownloadFilename('/')).toBe('file');
+    expect(sanitizeDownloadFilename('//')).toBe('file');
+    expect(sanitizeDownloadFilename('\\\\')).toBe('file');
+  });
+
+  it('falls back to "file" for an empty name', () => {
+    expect(sanitizeDownloadFilename('')).toBe('file');
+  });
+
+  it('preserves dotfiles and unicode', () => {
+    expect(sanitizeDownloadFilename('.env')).toBe('.env');
+    expect(sanitizeDownloadFilename('dir/ünïcødé.txt')).toBe('ünïcødé.txt');
+  });
+});

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ProgressPipe } from '../src/util/progress.js';
+
+describe('ProgressPipe', () => {
+  it('does not call the callback before one is attached', () => {
+    const pipe = new ProgressPipe();
+    pipe.setTotal(1000);
+    pipe.report(500);
+    // No callback set yet — nothing to assert beyond "no throw"; the
+    // crucial thing is the next test, which verifies the buffered state
+    // surfaces when the callback is finally attached.
+    expect(true).toBe(true);
+  });
+
+  it('emits 0–100 percentages when total is known', () => {
+    const pipe = new ProgressPipe();
+    const cb = vi.fn();
+    pipe.setTotal(1000);
+    pipe.setCallback(cb);
+
+    pipe.report(0);
+    pipe.report(250);
+    pipe.report(1000);
+
+    expect(cb.mock.calls).toEqual([[0], [25], [100]]);
+  });
+
+  it('clamps overshoot to 100', () => {
+    // received > total can happen if the server lies about Content-Length
+    // (or returns a Range whose total doesn't match) — clamp so consumers
+    // don't see "147%".
+    const pipe = new ProgressPipe();
+    const cb = vi.fn();
+    pipe.setTotal(100);
+    pipe.setCallback(cb);
+
+    pipe.report(147);
+    expect(cb).toHaveBeenLastCalledWith(100);
+  });
+
+  it('emits undefined on every chunk when total is unknown', () => {
+    // Content-Length absent → indeterminate. The callback still fires so
+    // consumers can switch into "stream has started" UI.
+    const pipe = new ProgressPipe();
+    const cb = vi.fn();
+    pipe.setCallback(cb);
+
+    pipe.report(100);
+    pipe.report(200);
+    pipe.report(300);
+
+    expect(cb.mock.calls).toEqual([[undefined], [undefined], [undefined]]);
+  });
+
+  it('replays the latest state when callback is attached after report', () => {
+    // The small-payload case: inspect() drains the whole stream before
+    // decrypt() gets a chance to attach the progress callback. Without
+    // buffered replay, the consumer would never see a single event and
+    // the UI would be stuck in its pre-download state.
+    const pipe = new ProgressPipe();
+    pipe.setTotal(200);
+    pipe.report(50);
+    pipe.report(200); // drained
+
+    const cb = vi.fn();
+    pipe.setCallback(cb);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(100);
+  });
+
+  it('replays undefined when the callback is attached after reports but total is unknown', () => {
+    const pipe = new ProgressPipe();
+    pipe.report(50);
+
+    const cb = vi.fn();
+    pipe.setCallback(cb);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not replay when no bytes have flowed yet', () => {
+    // Just setting total without any report() should not fire — there
+    // is genuinely no state to report.
+    const pipe = new ProgressPipe();
+    pipe.setTotal(100);
+
+    const cb = vi.fn();
+    pipe.setCallback(cb);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('continues firing on later reports after a late-attach replay', () => {
+    // The mid-payload case: some bytes flowed during inspect (replayed
+    // on setCallback), and more flow during unsealAndCollect.
+    const pipe = new ProgressPipe();
+    pipe.setTotal(1000);
+    pipe.report(100); // header read during inspect
+
+    const cb = vi.fn();
+    pipe.setCallback(cb); // replay → 10
+    pipe.report(500); // → 50
+    pipe.report(1000); // → 100
+
+    expect(cb.mock.calls).toEqual([[10], [50], [100]]);
+  });
+
+  it('updating total mid-stream affects subsequent reports only', () => {
+    // setTotal is exposed because the stream learns Content-Length
+    // from the first response; if a retry surfaces a different total
+    // we use the latest. Not a real-world case for the current API,
+    // but the behavior should be sane.
+    const pipe = new ProgressPipe();
+    const cb = vi.fn();
+    pipe.setCallback(cb);
+
+    pipe.setTotal(undefined);
+    pipe.report(100); // [undefined]
+
+    pipe.setTotal(1000);
+    pipe.report(250); // [25]
+
+    expect(cb.mock.calls).toEqual([[undefined], [25]]);
+  });
+});

--- a/tests/zip.test.ts
+++ b/tests/zip.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { readZipFilenames, extractZipEntry, createZipReadable } from '../src/util/zip.js';
+import {
+  readZipFilenames,
+  extractZipEntry,
+  createZipReadable,
+  extractAllZipEntries,
+} from '../src/util/zip.js';
 
 async function deflateRaw(data: Uint8Array): Promise<Uint8Array> {
   const cs = new CompressionStream('deflate-raw');
@@ -171,6 +176,91 @@ describe('extractZipEntry', () => {
   it('throws when the named entry is absent', async () => {
     const zip = createMinimalZip([{ name: 'data.bin', content: new Uint8Array([1]) }]);
     await expect(extractZipEntry(zip, 'missing.bin')).rejects.toThrow(/not found/);
+  });
+});
+
+describe('extractAllZipEntries', () => {
+  it('extracts a single stored entry', async () => {
+    const payload = new Uint8Array([10, 20, 30, 40]);
+    const zip = createMinimalZip([{ name: 'data.bin', content: payload }]);
+
+    const entries = await extractAllZipEntries(zip);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('data.bin');
+    expect(new Uint8Array(await entries[0].blob.arrayBuffer())).toEqual(payload);
+  });
+
+  it('extracts multiple stored entries in central-directory order', async () => {
+    const a = new Uint8Array([1, 1, 1]);
+    const b = new Uint8Array([2, 2, 2, 2]);
+    const c = new Uint8Array([3]);
+    const zip = createMinimalZip([
+      { name: 'a.bin', content: a },
+      { name: 'b.bin', content: b },
+      { name: 'c.bin', content: c },
+    ]);
+
+    const entries = await extractAllZipEntries(zip);
+
+    expect(entries.map((e) => e.name)).toEqual(['a.bin', 'b.bin', 'c.bin']);
+    expect(new Uint8Array(await entries[0].blob.arrayBuffer())).toEqual(a);
+    expect(new Uint8Array(await entries[1].blob.arrayBuffer())).toEqual(b);
+    expect(new Uint8Array(await entries[2].blob.arrayBuffer())).toEqual(c);
+  });
+
+  it('skips directory entries', async () => {
+    const payload = new Uint8Array([42]);
+    const zip = createMinimalZip([
+      { name: 'dir/' },
+      { name: 'dir/file.txt', content: payload },
+    ]);
+
+    const entries = await extractAllZipEntries(zip);
+
+    expect(entries.map((e) => e.name)).toEqual(['dir/file.txt']);
+    expect(new Uint8Array(await entries[0].blob.arrayBuffer())).toEqual(payload);
+  });
+
+  it('handles a streaming-mode deflate entry (conflux shape)', async () => {
+    // Verifies the deflate branch end-to-end: the zip writer leaves
+    // LFH sizes at 0; readCentralDirectory + extractAllZipEntries must
+    // pick the true sizes off the central directory.
+    const payload = new Uint8Array(2048);
+    for (let i = 0; i < payload.length; i++) payload[i] = (i * 31 + 7) & 0xff;
+
+    const zip = await createStreamingDeflateZip('data.bin', payload);
+
+    const entries = await extractAllZipEntries(zip);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('data.bin');
+    expect(new Uint8Array(await entries[0].blob.arrayBuffer())).toEqual(payload);
+  });
+
+  it('returns an empty array for an empty ZIP (no entries)', async () => {
+    const zip = createMinimalZip([]);
+    const entries = await extractAllZipEntries(zip);
+    expect(entries).toEqual([]);
+  });
+
+  it('preserves input order even under concurrent workers', async () => {
+    // The bounded worker pool resolves entries in completion order
+    // internally; the result array must still mirror the central-
+    // directory order regardless of decompression timing.
+    const entries = Array.from({ length: 12 }, (_, i) => ({
+      name: `f${String(i).padStart(2, '0')}.bin`,
+      content: new Uint8Array([i]),
+    }));
+    const zip = createMinimalZip(entries);
+
+    const extracted = await extractAllZipEntries(zip);
+
+    expect(extracted.map((e) => e.name)).toEqual(entries.map((e) => e.name));
+    for (let i = 0; i < entries.length; i++) {
+      const bytes = new Uint8Array(await extracted[i].blob.arrayBuffer());
+      expect(bytes).toEqual(entries[i].content);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `onDownloadProgress` to `DecryptInput` so consumers can render a real progress bar during `decrypt()`. Uses a mutable-callback `ProgressPipe` to bridge the gap between the lazy download stream (created in `inspect()`) and the actual byte flow (during `decrypt()`).
- Total size comes from the response's `Content-Length` header. When absent the callback fires with `undefined` so the UI can switch to an indeterminate indicator.
- Auto-extracts the inner ZIP. `DecryptFileResult.files` is now `Array<{ name: string; blob: Blob }>` and `download()` triggers one browser download per file. The single-entry `data.bin` shortcut (raw-data round trip → `DecryptDataResult`) is preserved.
- Adds a `prepare` script so this branch can be installed as a git dependency for cross-repo testing (needed by the companion website PR).

## Breaking changes
- `DecryptFileResult.files: string[]` → `Array<{ name: string; blob: Blob }>`
- `DecryptFileResult.blob` removed
- `DecryptFileResult.download(filename?)` → `download()` (no args, fans out)

Companion PR on the website: encryption4all/postguard-website#241

## Test plan
- [x] `npm test` — 116/116 pass (updated `tests/api.test.ts` for new `downloadFileWithRetry` return shape)
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual end-to-end via the companion website PR