### PR TITLE
fix(upload): pin onUploadInit acceptance with a regression test

### DIFF
--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -155,6 +155,22 @@ describe('PostGuard', () => {
         /does not support data: ReadableStream/
       );
     });
+
+    // Regression: a previous runtime validator hand-maintained an
+    // allowlist of upload keys and rejected `onUploadInit` because the
+    // type was updated but the allowlist wasn't. The validator has
+    // since been removed; this test pins the contract so a future
+    // attempt to reintroduce one can't silently re-break the option.
+    it('does not reject onUploadInit as an unknown option', async () => {
+      const sealed = pg.encrypt({
+        files: [new File([new Uint8Array([0])], 'a.bin')],
+        recipients: [pg.recipient.email('alice@example.com')],
+        sign: pg.sign.apiKey('PG-test'),
+      });
+      await expect(
+        sealed.upload({ onUploadInit: () => {} })
+      ).rejects.not.toThrow(/unknown option "onUploadInit"/);
+    });
   });
 
   describe('silent-default notice', () => {


### PR DESCRIPTION
## Summary
PR #87 (which removed the drift-prone runtime validator that was rejecting \`onUploadInit\`) landed under a \`refactor:\` prefix, so semantic-release didn't bump a version and consumers on \`@e4a/pg-js@2.0.0\` still hit the original \`TypeError\` when passing \`onUploadInit\`.

This PR:
- Re-records the same effective fix under a \`fix:\` prefix so the patch release actually ships.
- Adds a regression test that asserts \`sealed.upload({ onUploadInit })\` does not throw "unknown option" — pinning the behaviour so any future attempt to reintroduce a hand-maintained allowlist can't silently re-break the option.

## Test plan
- [x] \`npm test\` — 140 passed (139 + 1 new regression).
- [ ] After merge: confirm semantic-release publishes a new patch (e.g. \`2.0.1\`) and the bump propagates to postguard-website via dependabot / manual bump.

Unblocks encryption4all/postguard-website#244.