### PR TITLE
fix(decrypt): surface verified private signing identity to recipients

### DIFF
--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -147,8 +147,15 @@ export async function unsealAndCollect(
     },
   });
 
+  // pg-wasm's StreamUnsealer.unseal resolves with the VerificationResult
+  // — { public, private? } — derived from the inner IBS signature once
+  // decryption finishes. Capture it so the recipient sees the *private*
+  // signing identity (name, mobile, dateofbirth, …) the sender disclosed
+  // at sign time. The pre-unseal `public_identity()` carries only the
+  // public side, so the post-unseal value supersedes it when present.
+  let verified: SenderIdentity | undefined;
   try {
-    await unsealer.unseal(key, usk, writable);
+    verified = (await unsealer.unseal(key, usk, writable)) as SenderIdentity | undefined;
   } catch (e) {
     // AbortError signals user/caller-driven cancellation — surface it as-is
     // so callers can distinguish it from a real identity mismatch.
@@ -159,7 +166,7 @@ export async function unsealAndCollect(
     throw new IdentityMismatchError({ cause: e });
   }
 
-  let sender = preUnsealSender;
+  let sender: SenderIdentity | null = verified ?? preUnsealSender;
   if (!sender) {
     try {
       sender = unsealer.public_identity();

--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -147,12 +147,6 @@ export async function unsealAndCollect(
     },
   });
 
-  // pg-wasm's StreamUnsealer.unseal resolves with the VerificationResult
-  // — { public, private? } — derived from the inner IBS signature once
-  // decryption finishes. Capture it so the recipient sees the *private*
-  // signing identity (name, mobile, dateofbirth, …) the sender disclosed
-  // at sign time. The pre-unseal `public_identity()` carries only the
-  // public side, so the post-unseal value supersedes it when present.
   let verified: SenderIdentity | undefined;
   try {
     verified = (await unsealer.unseal(key, usk, writable)) as SenderIdentity | undefined;

--- a/tests/decrypt.test.ts
+++ b/tests/decrypt.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { unsealAndCollect } from '../src/crypto/decrypt.js';
 import { IdentityMismatchError } from '../src/errors.js';
+import type { SenderIdentity } from '../src/types.js';
 
-/** Minimal fake unsealer matching the shape `unsealAndCollect` uses. */
-function fakeUnsealer(unsealImpl: () => Promise<void>) {
+/** Minimal fake unsealer matching the shape `unsealAndCollect` uses.
+ *  `unsealImpl` may resolve to a SenderIdentity (the verified `{public,
+ *  private}` policy that `StreamUnsealer.unseal` returns from
+ *  pg-wasm). Callers that only care about the failure path return
+ *  `void`/`undefined` — both are fine. */
+function fakeUnsealer(
+  unsealImpl: () => Promise<SenderIdentity | void>,
+  publicIdentity: SenderIdentity | null = null,
+) {
   return {
     unseal: unsealImpl,
-    public_identity: () => null,
+    public_identity: () => publicIdentity,
   };
 }
 
@@ -43,5 +51,32 @@ describe('unsealAndCollect', () => {
     );
 
     expect(err).toBeInstanceOf(IdentityMismatchError);
+  });
+
+  it('captures the verified private signing identity returned by unseal', async () => {
+    // pg-wasm StreamUnsealer.unseal resolves with VerificationResult
+    // = { public, private? } once decryption + IBS verification of the
+    // inner private signature finishes. Before unseal only the public
+    // side is known; after unseal the private side becomes available.
+    const preUnseal: SenderIdentity = {
+      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'sender@example.com' }] },
+    };
+    const verified: SenderIdentity = {
+      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'sender@example.com' }] },
+      private: {
+        con: [
+          { t: 'pbdf.gemeente.personalData.fullname', v: 'R.A. Hensen' },
+          { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31630222348' },
+          { t: 'pbdf.gemeente.personalData.dateofbirth', v: '27-05-1996' },
+        ],
+      },
+    };
+
+    const unsealer = fakeUnsealer(() => Promise.resolve(verified));
+
+    const { sender } = await unsealAndCollect(unsealer, 'recipient@example.com', {}, preUnseal);
+
+    expect(sender?.private?.con).toBeDefined();
+    expect(sender?.private?.con).toEqual(verified.private!.con);
   });
 });

--- a/tests/decrypt.test.ts
+++ b/tests/decrypt.test.ts
@@ -54,15 +54,11 @@ describe('unsealAndCollect', () => {
   });
 
   it('captures the verified private signing identity returned by unseal', async () => {
-    // pg-wasm StreamUnsealer.unseal resolves with VerificationResult
-    // = { public, private? } once decryption + IBS verification of the
-    // inner private signature finishes. Before unseal only the public
-    // side is known; after unseal the private side becomes available.
     const preUnseal: SenderIdentity = {
-      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'sender@example.com' }] },
+      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'pre-unseal@example.com' }] },
     };
     const verified: SenderIdentity = {
-      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'sender@example.com' }] },
+      public: { con: [{ t: 'pbdf.sidn-pbdf.email.email', v: 'verified@example.com' }] },
       private: {
         con: [
           { t: 'pbdf.gemeente.personalData.fullname', v: 'R.A. Hensen' },
@@ -76,7 +72,7 @@ describe('unsealAndCollect', () => {
 
     const { sender } = await unsealAndCollect(unsealer, 'recipient@example.com', {}, preUnseal);
 
-    expect(sender?.private?.con).toBeDefined();
+    expect(sender?.public.con).toEqual(verified.public.con);
     expect(sender?.private?.con).toEqual(verified.private!.con);
   });
 });


### PR DESCRIPTION
## Summary

- `unsealAndCollect` discarded the value returned by `StreamUnsealer.unseal(...)`. pg-wasm resolves that promise with the full `VerificationResult { public, private? }` derived from the inner IBS signature; throwing it away meant every attribute the sender signed under the **private** signing identity (name, mobile, dateofbirth, …) was invisible to the recipient, even though the protocol makes them recoverable and verifiable.
- The post-unseal fallback to `public_identity()` only surfaced the public side, so `FriendlySender.attributes` consistently ended up with just the sender's email.
- Capture the unseal return value and prefer it over the pre-unseal identity. `parseSender` already merges public + private cons into `attributes`, so nothing else needed to change.
- New unit test for `unsealAndCollect` against a stub unsealer locks the behavior in.