### PR TITLE
fix(yivi): use SSE for session status, fall back to polling

### DIFF
--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -163,7 +163,14 @@ export async function resolveSigningKeysFromYivi(
     minimal: true,
     language: 'en',
     state: {
-      serverSentEvents: false,
+      // Prefer the irmaserver's Server-Sent Events stream (/frontend/statusevents)
+      // for near-instant status updates; yivi-client automatically falls back to
+      // polling if the SSE connection can't be established within `timeout`.
+      // (Previously this was `false`, which forced polling for every session.)
+      serverSentEvents: {
+        endpoint: 'statusevents',
+        timeout: 2000,
+      },
       polling: {
         endpoint: 'status',
         interval: 500,

--- a/src/yivi/decrypt-session.ts
+++ b/src/yivi/decrypt-session.ts
@@ -194,7 +194,14 @@ export async function retrieveUSKViaYivi(
     minimal: true,
     language: 'en',
     state: {
-      serverSentEvents: false,
+      // Prefer the irmaserver's Server-Sent Events stream (/frontend/statusevents)
+      // for near-instant status updates; yivi-client automatically falls back to
+      // polling if the SSE connection can't be established within `timeout`.
+      // (Previously this was `false`, which forced polling for every session.)
+      serverSentEvents: {
+        endpoint: 'statusevents',
+        timeout: 2000,
+      },
       polling: {
         endpoint: 'status',
         interval: 500,


### PR DESCRIPTION
## Problem

Yivi sessions always used the 500ms polling loop for status updates instead of the irmaserver's push stream. Reported in encryption4all/postguard-website#317.

Root cause is here in pg-js: both Yivi flows hardcoded `serverSentEvents: false` in the `YiviCore` `state` config:

- `src/signing/yivi.ts` (`resolveSigningKeysFromYivi`)
- `src/yivi/decrypt-session.ts` (`retrieveUSKViaYivi`)

`yivi-client`'s `StatusListener` selects its method with `serverSentEvents && hasNativeEventSource() ? "sse" : "polling"`, so `false` forces polling on every session. This has been the case since the first pg-js commit, with no explaining comment. `yivi-client`'s own default is SSE-on (`{ endpoint: 'statusevents', timeout: 2000 }`) with polling as fallback.

## Fix

Enable SSE explicitly in both flows (matching yivi-client's default), keeping polling as the documented fallback. yivi-client automatically falls back to polling if the SSE connection can't be established within the timeout, so this is strictly an improvement — near-instant updates where SSE works, identical behaviour where it doesn't.

## Verification

- `npm run typecheck`, `npm run build`, and `npm test` (205 tests) all pass.
- The Yivi session flow has no unit coverage (needs a DOM + live irmaserver), so no test was added/updated. The push path is best confirmed post-release in the browser: with a live PKG you should see an open `statusevents` EventSource connection instead of repeated `status` requests every 500ms.

Note: SSE only takes effect if the irmaserver's `/frontend/statusevents` is reachable **unbuffered** through the proxy fronting the PKG; a buffering proxy makes the client wait `timeout` (2s) then fall back to polling.

Closes encryption4all/postguard-website#317