### PR TITLE
feat(sign): prepareSign() — pre-warm a Yivi session for one-tap app open on iOS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ export type {
   SessionSign,
   SessionCallback,
   SessionRequest,
+  // Pre-warmed signing (pg.prepareSign)
+  PrepareSignOptions,
+  PreparedSign,
+  SigningKeys,
   // New API input/output
   EncryptInput,
   UploadOptions,

--- a/src/postguard.ts
+++ b/src/postguard.ts
@@ -1,13 +1,66 @@
-import type { EncryptInput, OpenInput } from './types.js';
+import type { EncryptInput, OpenInput, PrepareSignOptions, PreparedSign } from './types.js';
 import { PostGuardBase } from './postguard-base.js';
 import { Sealed } from './sealed.js';
 import { Opened } from './opened.js';
+import { resolveSigningKeysFromYivi } from './signing/yivi.js';
 
 export class PostGuard extends PostGuardBase {
   /** Prepare an encryption operation. Returns a lazy Sealed builder —
    *  nothing executes until you call .toBytes() or .upload(). */
   encrypt(options: EncryptInput): Sealed {
     return new Sealed(this.config, options);
+  }
+
+  /** Start a Yivi signing session ahead of time and hand back the app
+   *  deep-link URL as soon as it is known, plus a promise for the resolved
+   *  signing keys.
+   *
+   *  Why: on iOS a Yivi Universal Link only opens the app when the navigation
+   *  happens inside a genuine user gesture. If you wait until the user taps
+   *  "send" to start the session, the URL doesn't exist yet, so you can't
+   *  navigate synchronously and the tap falls back to Safari. Pre-warming the
+   *  session (e.g. once the compose form is valid) means the URL is ready at
+   *  tap time: render "send" as an `<a href={await mobileUrl}>` and one tap
+   *  opens the app. Then feed `await keys` into `encrypt({ signingKeys })`,
+   *  which reuses the disclosure instead of starting a second session.
+   *
+   *  The disclosure is identity-bound (sender email + optional attributes) and
+   *  independent of the files/recipients, so the keys are valid for whatever
+   *  you ultimately encrypt. Requires a DOM. */
+  prepareSign(opts: PrepareSignOptions): PreparedSign {
+    const abort = new AbortController();
+    const signal = opts.signal
+      ? AbortSignal.any([opts.signal, abort.signal])
+      : abort.signal;
+
+    let resolveUrl!: (url: string) => void;
+    let rejectUrl!: (err: unknown) => void;
+    const mobileUrl = new Promise<string>((resolve, reject) => {
+      resolveUrl = resolve;
+      rejectUrl = reject;
+    });
+    // If nobody awaits mobileUrl (e.g. desktop), keep a failed session from
+    // surfacing as an unhandled rejection — the caller still sees it via keys.
+    mobileUrl.catch(() => {});
+
+    const keys = resolveSigningKeysFromYivi(
+      this.config.pkgUrl,
+      {
+        element: opts.element,
+        senderEmail: opts.senderEmail,
+        attributes: opts.attributes,
+        includeSender: opts.includeSender,
+      },
+      this.config.headers,
+      { onMobileUrl: resolveUrl, signal },
+    ).catch((err) => {
+      // Surface an early failure (cancel/timeout before the button showed) to
+      // anyone awaiting the URL, then propagate to `keys`.
+      rejectUrl(err);
+      throw err;
+    });
+
+    return { mobileUrl, keys, cancel: () => abort.abort() };
   }
 
   /** Open encrypted data for inspection or decryption. Returns a lazy Opened builder —

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -28,8 +28,11 @@ export class Sealed {
     return !!this.config.cryptifyUrl;
   }
 
-  /** Resolve signing keys once and cache for subsequent calls. */
+  /** Resolve signing keys once and cache for subsequent calls. When the caller
+   *  supplies pre-resolved keys (e.g. from pg.prepareSign()), use them directly
+   *  and never start a Yivi session. */
   private async getSigningKeys(): Promise<SigningKeys> {
+    if (this.options.signingKeys) return this.options.signingKeys;
     if (!this.cachedSigningKeys) {
       this.cachedSigningKeys = await resolveSigningKeys(
         this.config.pkgUrl,

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -13,6 +13,19 @@ export interface YiviSignOptions {
   includeSender?: boolean;
 }
 
+/** Runtime hooks for a Yivi signing session — kept separate from
+ *  `YiviSignOptions` (which describes the disclosure request) because these
+ *  concern the live session, not its contents. */
+export interface YiviSignRuntime {
+  /** Called once with the Yivi app deep-link URL as soon as the session
+   *  pointer is known and Yivi shows its mobile app button. Lets a caller
+   *  (`prepareSign`) hand the URL to an `<a href>` so a single user tap opens
+   *  the app. Fires on mobile only; on desktop the QR flow is used instead. */
+  onMobileUrl?: (url: string) => void;
+  /** Abort the session (cancels `yivi.start()` and clears the host element). */
+  signal?: AbortSignal;
+}
+
 /** Build the JSON body POSTed to `${pkgUrl}/v2/request/start`.
  *  Exposed for unit testing — the runtime call path uses it via `JSON.stringify`. */
 export function buildStartRequestBody(opts: YiviSignOptions): {
@@ -96,13 +109,18 @@ export function parseDisclosedJwt(
 export async function resolveSigningKeysFromYivi(
   pkgUrl: string,
   opts: YiviSignOptions,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  runtime?: YiviSignRuntime
 ): Promise<SigningKeys> {
   if (typeof document === 'undefined') {
     throw new YiviSessionError(
       'sign.yivi requires a DOM (browser environment). ' +
       'Use sign.apiKey for server-side encryption or sign.session with a custom callback.'
     );
+  }
+
+  if (runtime?.signal?.aborted) {
+    throw new YiviSessionError('Aborted');
   }
 
   const extraHeaders = headers ? Object.fromEntries(new Headers(headers)) : {};
@@ -183,6 +201,33 @@ export async function resolveSigningKeysFromYivi(
 
   yivi.use(YiviWeb);
   yivi.use(YiviClient);
+
+  // Passive listener plugin: yivi-core hands every plugin each state change,
+  // and the mobile "ShowingYiviButton" state carries the app deep-link URL in
+  // its payload (`mobile`). Capture it here — cleaner than scraping the
+  // rendered `.yivi-web-button-link` href — so `prepareSign` can surface the
+  // URL for a one-tap app open. Has no `start`, so yivi-core never drives it.
+  if (runtime?.onMobileUrl) {
+    const onMobileUrl = runtime.onMobileUrl;
+    let fired = false;
+    class MobileUrlCapture {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      constructor(_deps: unknown) {}
+      stateChange(state: { newState?: string; payload?: { mobile?: string } }): void {
+        if (!fired && state?.newState === 'ShowingYiviButton' && state.payload?.mobile) {
+          fired = true;
+          onMobileUrl(state.payload.mobile);
+        }
+      }
+    }
+    yivi.use(MobileUrlCapture as any);
+  }
+
+  // Let an external signal abort the in-flight session. yivi-core's abort()
+  // transitions the state machine to "Aborted", which rejects start() below.
+  if (runtime?.signal) {
+    runtime.signal.addEventListener('abort', () => yivi.abort(), { once: true });
+  }
 
   // yivi-core's start() rejects with a bare string final-state name on
   // anything other than Success ("Cancelled", "TimedOut", "Aborted").

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,10 +95,50 @@ export interface EncryptInput {
   recipients: Recipient[];
   /** Signing method */
   sign: SignMethod;
+  /** Pre-resolved signing keys — e.g. from `pg.prepareSign()`, which runs the
+   *  Yivi disclosure ahead of time so a mobile user can open the app on a
+   *  single genuine tap. When provided, encrypt() uses these directly and does
+   *  NOT start a new Yivi session (the `sign.element` widget is never touched).
+   *  `sign` is still required: it supplies envelope metadata and, when
+   *  `includeSender` is set, the friendly-sender line (from `senderEmail`). */
+  signingKeys?: SigningKeys;
   /** Progress callback (0-100) for upload operations */
   onProgress?: (percentage: number) => void;
   /** Abort signal for cancellation */
   signal?: AbortSignal;
+}
+
+/** Options for pg.prepareSign() — start a Yivi signing session ahead of the
+ *  actual encrypt() call. Mirrors the Yivi fields of a `sign` method; the
+ *  disclosure it performs is identity-bound (sender email + optional
+ *  attributes) and independent of the files/recipients, so the resolved keys
+ *  can be reused for whatever is ultimately encrypted. */
+export interface PrepareSignOptions {
+  /** DOM selector for the Yivi widget host. On mobile you can keep this
+   *  offscreen/hidden and drive the app open from `mobileUrl` instead. */
+  element: string;
+  senderEmail?: string;
+  attributes?: AttrConItem[];
+  includeSender?: boolean;
+  /** Abort the in-flight session from outside (in addition to `cancel()`). */
+  signal?: AbortSignal;
+}
+
+/** Handle returned by pg.prepareSign(). */
+export interface PreparedSign {
+  /** Resolves with the Yivi app deep-link URL once the session pointer is
+   *  known — put it on an `<a href>` so a single user tap opens the app on
+   *  iOS (a Universal Link only hands off to the app inside a genuine
+   *  gesture). Only settles on mobile, where Yivi shows the app button; on
+   *  desktop (QR flow) it stays pending, so race it with a timeout there.
+   *  Rejects if the session fails before the button is shown. */
+  mobileUrl: Promise<string>;
+  /** Resolves with signing keys when the user completes disclosure. Pass into
+   *  encrypt() via `signingKeys`. Rejects with YiviSessionError on
+   *  cancel/timeout/close. */
+  keys: Promise<SigningKeys>;
+  /** Abort the in-flight session and clean up the widget host. */
+  cancel(): void;
 }
 
 /** Options for sealed.upload() */

--- a/tests/postguard.test.ts
+++ b/tests/postguard.test.ts
@@ -374,4 +374,69 @@ describe('PostGuard', () => {
       ).rejects.toThrow(/sign\.yivi requires a DOM/);
     });
   });
+
+  describe('prepareSign', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('returns a handle with mobileUrl, keys and cancel', () => {
+      vi.stubGlobal('document', undefined);
+      const prepared = pg.prepareSign({ element: '#yivi' });
+      expect(prepared.mobileUrl).toBeInstanceOf(Promise);
+      expect(prepared.keys).toBeInstanceOf(Promise);
+      expect(typeof prepared.cancel).toBe('function');
+      // Swallow the expected DOM-guard rejection so it isn't reported as
+      // unhandled by this synchronous assertion test.
+      prepared.keys.catch(() => {});
+    });
+
+    it('rejects both keys and mobileUrl when no DOM is present', async () => {
+      // Without a DOM the session can't start; the early failure must reach
+      // whoever awaits the URL, not just whoever awaits the keys.
+      vi.stubGlobal('document', undefined);
+      const prepared = pg.prepareSign({ element: '#yivi' });
+      await expect(prepared.keys).rejects.toBeInstanceOf(YiviSessionError);
+      await expect(prepared.mobileUrl).rejects.toBeInstanceOf(YiviSessionError);
+    });
+
+    it('rejects immediately when the abort signal is already aborted', async () => {
+      // Stub a truthy document so we clear the DOM guard and hit the
+      // abort guard (which sits before any yivi-web construction).
+      vi.stubGlobal('document', {});
+      const prepared = pg.prepareSign({
+        element: '#yivi',
+        signal: AbortSignal.abort(),
+      });
+      await expect(prepared.keys).rejects.toThrow(/Aborted/);
+    });
+  });
+
+  describe('encrypt with pre-resolved signingKeys', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('skips the Yivi session (never touches sign.element) when keys are supplied', async () => {
+      // No DOM here: if getSigningKeys did NOT honor the supplied keys, it
+      // would fall through to resolveSigningKeysFromYivi and reject with the
+      // "requires a DOM" YiviSessionError. Proving the upload rejects for some
+      // OTHER reason (no real crypto/network in tests) confirms the pre-warmed
+      // keys short-circuited session resolution.
+      vi.stubGlobal('document', undefined);
+      const sealed = pg.encrypt({
+        files: [new File([new Uint8Array([1, 2, 3])], 'a.bin')],
+        recipients: [pg.recipient.email('a@b.com')],
+        sign: pg.sign.yivi({ element: '#never-rendered' }),
+        signingKeys: {
+          pubSignKey: 'PUB',
+          privSignKey: 'PRIV',
+          senderEmail: 'me@example.com',
+        },
+      });
+      await expect(
+        sealed.upload({ notify: { recipients: false } })
+      ).rejects.not.toThrow(/requires a DOM/);
+    });
+  });
 });


### PR DESCRIPTION
## Why

On iOS a Yivi **Universal Link** only opens the app when the navigation happens inside a **genuine user gesture**. Today the signing session is started as part of `encrypt()` — i.e. *after* the user taps send — so the app deep-link URL doesn't exist yet at tap time. There's nothing to navigate to synchronously, so the tap falls back to opening `open.yivi.app` in Safari instead of the app.

This adds the primitive needed to fix that in the website: start the session **before** the tap, so the URL is ready and a single tap can open the app.

## What

`PostGuard.prepareSign(opts)` starts the Yivi signing session ahead of time and returns:

- **`mobileUrl: Promise<string>`** — the Yivi app deep-link, resolved as soon as Yivi shows its mobile app button. Captured via a small passive **yivi-core state plugin** that reads the `ShowingYiviButton` payload's `mobile` field — no DOM scraping. Put it on an `<a href>` so one tap opens the app. Mobile-only (desktop uses the QR flow), so race with a timeout there.
- **`keys: Promise<SigningKeys>`** — resolves on disclosure; pass into `encrypt({ signingKeys })`.
- **`cancel()`** — aborts the in-flight session.

The disclosure is **identity-bound** (sender email + optional attributes) and independent of the files/recipients, so the resolved keys are valid for whatever is ultimately encrypted.

Supporting changes:
- `EncryptInput` gains an optional **`signingKeys`** field. When supplied, `Sealed.getSigningKeys()` uses it directly and never starts a second Yivi session (the `sign.element` widget is never touched). The internal pipeline already threaded `signingKeys`; this just surfaces it publicly.
- `resolveSigningKeysFromYivi` gains a `runtime` arg (`onMobileUrl`, `signal`) for the URL capture and `AbortSignal` cancellation.
- Exports `PrepareSignOptions`, `PreparedSign`, `SigningKeys`.

## Usage sketch (website side, follows separately)

```ts
// when the compose form becomes valid:
const prep = pg.prepareSign({ element: '#hidden-yivi', attributes: SIGN_ATTRS, includeSender: true });
const href = await prep.mobileUrl;         // put on the "Send" <a href>
// user taps the anchor -> Yivi app opens (one gesture)
const signingKeys = await prep.keys;       // resolves after disclosure
await pg.encrypt({ files, recipients, sign, signingKeys }).upload({ notify });
```

## Tests

- `prepareSign` returns `{ mobileUrl, keys, cancel }`; rejects both `keys` and `mobileUrl` with `YiviSessionError` when no DOM; rejects immediately on an already-aborted signal.
- `encrypt({ signingKeys })` short-circuits session resolution (no "requires a DOM" throw when keys are supplied).
- Full suite: 209 passing; `tsc --noEmit` clean; `tsdown` build clean.

The runtime `mobileUrl` capture path needs a browser + live Yivi server to exercise end-to-end; that happens in the website wiring PR and an on-device iOS check.