### PR TITLE
feat: configurable email attribute types (emailAttributes option)

### DIFF
--- a/src/api/pkg.ts
+++ b/src/api/pkg.ts
@@ -1,6 +1,7 @@
 import { NetworkError } from '../errors.js';
 import { mergeHeaders } from '../util/headers.js';
 import type { SigningKeys, SessionStartResult, AttributeCon } from '../types.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 
 /** Fetch the master public key from the PKG server */
 export async function fetchMPK(pkgUrl: string, headers?: HeadersInit): Promise<unknown> {
@@ -28,11 +29,17 @@ export async function fetchVerificationKey(pkgUrl: string, headers?: HeadersInit
   return json.publicKey;
 }
 
-/** Fetch signing keys using an API key (PostGuard for Business) */
+/** Fetch signing keys using an API key (PostGuard for Business).
+ *
+ *  Note: under API-key auth the PKG derives the signing identity from the
+ *  business database and ignores this body — the configured type is sent
+ *  anyway so the wire request stays consistent with the rest of the client
+ *  under an `emailAttributes` override. */
 export async function fetchSigningKeysWithApiKey(
   pkgUrl: string,
   apiKey: string,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  emailAttributes?: EmailAttributes
 ): Promise<SigningKeys> {
   const response = await fetch(`${pkgUrl}/v2/irma/sign/key`, {
     method: 'POST',
@@ -41,7 +48,7 @@ export async function fetchSigningKeysWithApiKey(
       Authorization: `Bearer ${apiKey}`,
     })),
     body: JSON.stringify({
-      pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
+      pubSignId: [{ t: (emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES).email }],
     }),
   });
   if (!response.ok) {

--- a/src/crypto/decrypt.ts
+++ b/src/crypto/decrypt.ts
@@ -5,6 +5,7 @@ import { getUSK } from '../api/pkg.js';
 import { downloadFile, downloadFileWithRetry } from '../api/cryptify.js';
 import { resolveRetryOptions, type RetryOptions } from '../util/retry.js';
 import { buildKeyRequest } from '../util/policy.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 import { retrieveUSKViaYivi } from '../yivi/decrypt-session.js';
 import { extractAllZipEntries } from '../util/zip.js';
 import { triggerBrowserDownloads } from '../util/download.js';
@@ -111,16 +112,18 @@ export async function resolveUSK(
   element?: string,
   session?: SessionCallback,
   headers?: HeadersInit,
-  enableCache?: boolean
+  enableCache?: boolean,
+  emailAttributes?: EmailAttributes
 ): Promise<unknown> {
-  const keyRequest = buildKeyRequest(recipientKey, policy);
+  const attrs = emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES;
+  const keyRequest = buildKeyRequest(recipientKey, policy, attrs);
 
   if (session) {
     const jwt = await session({
       con: keyRequest.con,
       sort: 'Decryption',
       hints: policy.con.map((c) => {
-        if (c.t === 'pbdf.sidn-pbdf.email.email') return { t: c.t, v: recipientKey };
+        if (c.t === attrs.email) return { t: c.t, v: recipientKey };
         return c;
       }),
     });

--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -3,6 +3,7 @@ import type { Recipient, SignMethod, SigningKeys, UploadResult, YiviSign } from 
 import { fetchMPK } from '../api/pkg.js';
 import { createUploadStream } from '../api/cryptify.js';
 import { buildEncryptionPolicy } from '../recipients/builders.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 import { resolveSigningKeys } from './signing.js';
 import Chunker, { withTransform } from './chunker.js';
 import { createZipReadable } from '../util/zip.js';
@@ -17,6 +18,8 @@ export interface EncryptPipelineOptions {
   sign: SignMethod;
   files: File[];
   recipients: Recipient[];
+  /** Email attribute types (see `PostGuardConfig.emailAttributes`). */
+  emailAttributes?: EmailAttributes;
   onProgress?: (percentage: number) => void;
   signal?: AbortSignal;
   /** Size (in bytes) of each chunk sent during upload. Defaults to 5 000 000 (5 MB). */
@@ -42,6 +45,7 @@ export interface EncryptPipelineOptions {
 /** Full encryption pipeline: sign -> policy -> ZIP -> seal -> upload */
 export async function encryptPipeline(options: EncryptPipelineOptions): Promise<UploadResult> {
   const { pkgUrl, cryptifyUrl, sign, files, recipients, onProgress, signal, delivery, headers } = options;
+  const emailAttrs = options.emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES;
 
   const abortController = new AbortController();
   const effectiveSignal = signal
@@ -51,19 +55,19 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   // Fetch MPK and signing keys in parallel
   const [mpk, signingKeys] = await Promise.all([
     fetchMPK(pkgUrl, headers),
-    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers),
+    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers, emailAttrs),
   ]);
 
   // Build encryption policy
   const ts = Math.round(Date.now() / 1000);
-  const policy = buildEncryptionPolicy(recipients, ts);
+  const policy = buildEncryptionPolicy(recipients, ts, emailAttrs);
 
   // If the sign method requests including the sender, add a sender entry
   // so the sender can also decrypt the sealed file.
   if (sign.type === 'yivi' && (sign as YiviSign).includeSender && signingKeys.senderEmail) {
     policy[signingKeys.senderEmail] = {
       ts,
-      con: [{ t: 'pbdf.sidn-pbdf.email.email', v: signingKeys.senderEmail }],
+      con: [{ t: emailAttrs.email, v: signingKeys.senderEmail }],
     };
   }
 
@@ -166,27 +170,30 @@ export interface SealRawOptions {
   headers?: HeadersInit;
   /** Pre-resolved signing keys (skips Yivi/API key resolution if provided) */
   signingKeys?: SigningKeys;
+  /** Email attribute types (see `PostGuardConfig.emailAttributes`). */
+  emailAttributes?: EmailAttributes;
 }
 
 /** Seal raw data: sign -> policy -> sealStream -> return encrypted bytes */
 export async function sealRaw(options: SealRawOptions): Promise<Uint8Array> {
   const { pkgUrl, sign, recipients, data, headers } = options;
+  const emailAttrs = options.emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES;
 
   // Fetch MPK and signing keys in parallel
   const [mpk, signingKeys] = await Promise.all([
     fetchMPK(pkgUrl, headers),
-    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers),
+    options.signingKeys ?? resolveSigningKeys(pkgUrl, sign, headers, emailAttrs),
   ]);
 
   // Build encryption policy
   const ts = Math.round(Date.now() / 1000);
-  const policy = buildEncryptionPolicy(recipients, ts);
+  const policy = buildEncryptionPolicy(recipients, ts, emailAttrs);
 
   // Include sender in policy if requested
   if (sign.type === 'yivi' && (sign as YiviSign).includeSender && signingKeys.senderEmail) {
     policy[signingKeys.senderEmail] = {
       ts,
-      con: [{ t: 'pbdf.sidn-pbdf.email.email', v: signingKeys.senderEmail }],
+      con: [{ t: emailAttrs.email, v: signingKeys.senderEmail }],
     };
   }
 

--- a/src/crypto/signing.ts
+++ b/src/crypto/signing.ts
@@ -13,7 +13,7 @@ export async function resolveSigningKeys(
 ): Promise<SigningKeys> {
   switch (sign.type) {
     case 'apiKey':
-      return resolveSigningKeysFromApiKey(pkgUrl, sign.apiKey, headers);
+      return resolveSigningKeysFromApiKey(pkgUrl, sign.apiKey, headers, emailAttributes);
     case 'yivi':
       return resolveSigningKeysFromYivi(pkgUrl, {
         element: sign.element,

--- a/src/crypto/signing.ts
+++ b/src/crypto/signing.ts
@@ -1,4 +1,5 @@
 import type { SignMethod, SigningKeys } from '../types.js';
+import type { EmailAttributes } from '../util/attributes.js';
 import { resolveSigningKeysFromApiKey } from '../signing/api-key.js';
 import { resolveSigningKeysFromYivi } from '../signing/yivi.js';
 import { resolveSigningKeysFromSession } from '../signing/session.js';
@@ -7,7 +8,8 @@ import { resolveSigningKeysFromSession } from '../signing/session.js';
 export async function resolveSigningKeys(
   pkgUrl: string,
   sign: SignMethod,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  emailAttributes?: EmailAttributes
 ): Promise<SigningKeys> {
   switch (sign.type) {
     case 'apiKey':
@@ -18,8 +20,9 @@ export async function resolveSigningKeys(
         senderEmail: sign.senderEmail,
         attributes: sign.attributes,
         includeSender: sign.includeSender,
+        emailAttributes,
       }, headers);
     case 'session':
-      return resolveSigningKeysFromSession(pkgUrl, sign.callback, sign.senderEmail, headers);
+      return resolveSigningKeysFromSession(pkgUrl, sign.callback, sign.senderEmail, headers, emailAttributes);
   }
 }

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -15,6 +15,7 @@ import {
   unsealAndCollect,
 } from './crypto/decrypt.js';
 import { extractAllZipEntries } from './util/zip.js';
+import { resolveEmailAttributes } from './util/attributes.js';
 import { triggerBrowserDownloads } from './util/download.js';
 import { parseSender } from './util/identity.js';
 import { ProgressPipe } from './util/progress.js';
@@ -88,6 +89,7 @@ export class Opened {
       opts.session,
       this.config.headers,
       opts.enableCache,
+      resolveEmailAttributes(this.config.emailAttributes),
     );
 
     // Attach progress callback just before we drain the stream: bytes

--- a/src/postguard-base.ts
+++ b/src/postguard-base.ts
@@ -12,11 +12,15 @@ import {
   PG_CLIENT_VERSION_HEADER,
   defaultClientVersionHeaderValue,
 } from './util/client-version.js';
+import { resolveEmailAttributes, type EmailAttributes } from './util/attributes.js';
 
 /** Base class with config, builders, and email helpers shared by PostGuard variants. */
 export class PostGuardBase {
   /** @internal */
   protected readonly config: PostGuardConfig;
+
+  /** Email attribute types, resolved once from the config (postguard#236). @internal */
+  protected readonly emailAttributes: EmailAttributes;
 
   /** Email helpers for building/parsing PostGuard-encrypted emails */
   readonly email: EmailHelpers;
@@ -32,6 +36,7 @@ export class PostGuardBase {
       headers.set(PG_CLIENT_VERSION_HEADER, defaultClientVersionHeaderValue());
     }
     this.config = { ...config, headers };
+    this.emailAttributes = resolveEmailAttributes(config.emailAttributes);
     this.email = new EmailHelpers(this.config);
   }
 

--- a/src/postguard.ts
+++ b/src/postguard.ts
@@ -50,6 +50,7 @@ export class PostGuard extends PostGuardBase {
         senderEmail: opts.senderEmail,
         attributes: opts.attributes,
         includeSender: opts.includeSender,
+        emailAttributes: this.emailAttributes,
       },
       this.config.headers,
       { onMobileUrl: resolveUrl, signal },

--- a/src/recipients/builders.ts
+++ b/src/recipients/builders.ts
@@ -1,15 +1,16 @@
 import type { Recipient, PolicyEntry } from '../types.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 
 function extractDomain(email: string): string {
   return email.split('@')[1] || '';
 }
 
 /** Build the full attribute constraint list for a recipient. */
-function buildCon(r: Recipient): { t: string; v: string }[] {
+function buildCon(r: Recipient, attrs: EmailAttributes): { t: string; v: string }[] {
   const base =
     r._baseType === 'email'
-      ? [{ t: 'pbdf.sidn-pbdf.email.email', v: r.email }]
-      : [{ t: 'pbdf.sidn-pbdf.email.domain', v: extractDomain(r.email) }];
+      ? [{ t: attrs.email, v: r.email }]
+      : [{ t: attrs.domain, v: extractDomain(r.email) }];
 
   return [...base, ...r._extras];
 }
@@ -17,14 +18,15 @@ function buildCon(r: Recipient): { t: string; v: string }[] {
 /** Build an encryption policy map from a list of recipients */
 export function buildEncryptionPolicy(
   recipients: Recipient[],
-  timestamp: number
+  timestamp: number,
+  attrs: EmailAttributes = DEFAULT_EMAIL_ATTRIBUTES
 ): Record<string, PolicyEntry> {
   const policy: Record<string, PolicyEntry> = {};
 
   for (const r of recipients) {
     policy[r.email] = {
       ts: timestamp,
-      con: buildCon(r),
+      con: buildCon(r, attrs),
     };
   }
 

--- a/src/sealed.ts
+++ b/src/sealed.ts
@@ -1,5 +1,6 @@
 import type { PostGuardConfig, EncryptInput, SigningKeys, UploadOptions, UploadResult } from './types.js';
 import { sealRaw } from './crypto/encrypt.js';
+import { resolveEmailAttributes } from './util/attributes.js';
 import { encryptPipeline } from './crypto/encrypt.js';
 import { createZipReadable } from './util/zip.js';
 import { resolveSigningKeys } from './crypto/signing.js';
@@ -38,6 +39,7 @@ export class Sealed {
         this.config.pkgUrl,
         this.options.sign,
         this.config.headers,
+        resolveEmailAttributes(this.config.emailAttributes),
       );
     }
     return this.cachedSigningKeys;
@@ -57,6 +59,7 @@ export class Sealed {
         data: this.options.data,
         headers: this.config.headers,
         signingKeys,
+        emailAttributes: resolveEmailAttributes(this.config.emailAttributes),
       });
     }
 
@@ -70,6 +73,7 @@ export class Sealed {
       data: zipReadable,
       headers: this.config.headers,
       signingKeys,
+      emailAttributes: resolveEmailAttributes(this.config.emailAttributes),
     });
   }
 
@@ -128,6 +132,7 @@ export class Sealed {
       delivery: opts?.notify,
       headers: this.config.headers,
       signingKeys,
+      emailAttributes: resolveEmailAttributes(this.config.emailAttributes),
       retry: this.config.retry,
       onUploadInit: opts?.onUploadInit,
     });

--- a/src/signing/api-key.ts
+++ b/src/signing/api-key.ts
@@ -1,11 +1,13 @@
 import { fetchSigningKeysWithApiKey } from '../api/pkg.js';
 import type { SigningKeys } from '../types.js';
+import type { EmailAttributes } from '../util/attributes.js';
 
 /** Resolve signing keys using an API key */
 export async function resolveSigningKeysFromApiKey(
   pkgUrl: string,
   apiKey: string,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  emailAttributes?: EmailAttributes
 ): Promise<SigningKeys> {
-  return fetchSigningKeysWithApiKey(pkgUrl, apiKey, headers);
+  return fetchSigningKeysWithApiKey(pkgUrl, apiKey, headers, emailAttributes);
 }

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -1,5 +1,6 @@
 import type { SessionCallback, SigningKeys } from '../types.js';
 import { getSigningKeysWithJwt } from '../api/pkg.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 
 /** Resolve signing keys by calling a user-provided session callback to get a JWT,
  *  then exchanging it with the PKG for signing keys. */
@@ -7,11 +8,13 @@ export async function resolveSigningKeysFromSession(
   pkgUrl: string,
   callback: SessionCallback,
   senderEmail: string | undefined,
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  emailAttributes?: EmailAttributes
 ): Promise<SigningKeys> {
+  const attrs = emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES;
   const emailAttr = senderEmail
-    ? { t: 'pbdf.sidn-pbdf.email.email', v: senderEmail }
-    : { t: 'pbdf.sidn-pbdf.email.email' };
+    ? { t: attrs.email, v: senderEmail }
+    : { t: attrs.email };
 
   const jwt = await callback({
     con: [emailAttr],
@@ -21,7 +24,7 @@ export async function resolveSigningKeysFromSession(
   return getSigningKeysWithJwt(
     pkgUrl,
     jwt,
-    { pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }] },
+    { pubSignId: [{ t: attrs.email }] },
     headers
   );
 }

--- a/src/signing/yivi.ts
+++ b/src/signing/yivi.ts
@@ -5,12 +5,15 @@ import { injectYiviCss } from '../yivi/inject-css.js';
 import { YiviSessionError } from '../errors.js';
 import { decodeJwtPayloadUnsafe } from '../util/jwt.js';
 import type { SigningKeys, AttrConItem, AttrReq } from '../types.js';
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attributes.js';
 
 export interface YiviSignOptions {
   element: string;
   senderEmail?: string;
   attributes?: AttrConItem[];
   includeSender?: boolean;
+  /** Email attribute types (see `PostGuardConfig.emailAttributes`). */
+  emailAttributes?: EmailAttributes;
 }
 
 /** Runtime hooks for a Yivi signing session — kept separate from
@@ -31,10 +34,11 @@ export interface YiviSignRuntime {
 export function buildStartRequestBody(opts: YiviSignOptions): {
   con: AttrConItem[];
 } {
+  const emailType = (opts.emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES).email;
   const emailAttr: AttrReq = opts.senderEmail
-    ? { t: 'pbdf.sidn-pbdf.email.email', v: opts.senderEmail }
-    : { t: 'pbdf.sidn-pbdf.email.email' };
-  // Callers must not include pbdf.sidn-pbdf.email.email in `attributes`; it
+    ? { t: emailType, v: opts.senderEmail }
+    : { t: emailType };
+  // Callers must not include the email attribute type in `attributes`; it
   // is always prepended automatically and would appear twice otherwise.
   return { con: [emailAttr, ...(opts.attributes ?? [])] };
 }
@@ -72,7 +76,7 @@ export function collectRequestedAttrTypes(attributes?: AttrConItem[]): Set<strin
  * types flow into the signing-key request sent to PKG. Any disclosed attribute
  * type the client never asked for is ignored. `email` is used only for the
  * display/identity value and never drives the key request body (which always
- * uses the fixed `pbdf.sidn-pbdf.email.email` type id).
+ * uses the configured email attribute type id).
  *
  * Returns the sender email and the de-duplicated list of allowed disclosed
  * attribute type ids.
@@ -153,7 +157,7 @@ export async function resolveSigningKeysFromYivi(
             // - pubSignId: email (always public)
             // - privSignId: any other disclosed attributes (optional sender identity)
             const keyRequest: Record<string, unknown> = {
-              pubSignId: [{ t: 'pbdf.sidn-pbdf.email.email' }],
+              pubSignId: [{ t: (opts.emailAttributes ?? DEFAULT_EMAIL_ATTRIBUTES).email }],
             };
             if (otherAttrTypes.length > 0) {
               keyRequest.privSignId = otherAttrTypes.map(t => ({ t }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,13 @@ export interface PostGuardConfig {
    * 404) and caller-driven aborts are not retried.
    */
   retry?: RetryOptions;
+  /**
+   * Attribute types carrying the email identity (default: the production
+   * pbdf types). Test environments override these with test-scheme types
+   * (e.g. `irma-demo.sidn-pbdf.email.email`); overrides must match the PKG's
+   * `PKG_EMAIL_ATTRIBUTE` and cryptify's `email_attribute` settings.
+   */
+  emailAttributes?: { email?: string; domain?: string };
 }
 
 // --- Recipients ---

--- a/src/util/attributes.ts
+++ b/src/util/attributes.ts
@@ -1,0 +1,28 @@
+/**
+ * Attribute types carrying the email identity in policies, key requests and
+ * signing identities (postguard#236).
+ *
+ * Defaults are the production pbdf types. Test environments override them
+ * with test-scheme types (e.g. `irma-demo.sidn-pbdf.email.email`) — no test
+ * environment can issue `pbdf.*` credentials, since those issuer keys are
+ * production secrets. Overrides must match the PKG's `PKG_EMAIL_ATTRIBUTE`
+ * and cryptify's `email_attribute` settings.
+ */
+export interface EmailAttributes {
+  /** Attribute type for an exact email address. */
+  email: string;
+  /** Attribute type for an email domain. */
+  domain: string;
+}
+
+export const DEFAULT_EMAIL_ATTRIBUTES: EmailAttributes = {
+  email: 'pbdf.sidn-pbdf.email.email',
+  domain: 'pbdf.sidn-pbdf.email.domain',
+};
+
+/** Merge partial overrides (from `PostGuardConfig.emailAttributes`) with the defaults. */
+export function resolveEmailAttributes(
+  overrides?: Partial<EmailAttributes>
+): EmailAttributes {
+  return { ...DEFAULT_EMAIL_ATTRIBUTES, ...overrides };
+}

--- a/src/util/policy.ts
+++ b/src/util/policy.ts
@@ -11,18 +11,21 @@ export function secondsTill4AM(): number {
   return (secondsTillMidnight + 4 * 60 * 60) % (24 * 60 * 60);
 }
 
+import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from './attributes.js';
+
 /** Build the key request from a policy entry for a specific recipient */
 export function buildKeyRequest(
   key: string,
-  policy: { ts: number; con: { t: string; v?: string }[] }
+  policy: { ts: number; con: { t: string; v?: string }[] },
+  attrs: EmailAttributes = DEFAULT_EMAIL_ATTRIBUTES
 ): { con: { t: string; v?: string }[]; validity: number } {
   const recipientAndCreds = sortPolicies(policy.con);
 
   const stripped = JSON.parse(JSON.stringify(recipientAndCreds));
   for (const c of stripped) {
-    if (c.t === 'pbdf.sidn-pbdf.email.email') {
+    if (c.t === attrs.email) {
       c.v = key;
-    } else if (c.t === 'pbdf.sidn-pbdf.email.domain') {
+    } else if (c.t === attrs.domain) {
       if (!c.v && key.includes('@')) {
         c.v = key.split('@')[1];
       }

--- a/tests/email-attributes.test.ts
+++ b/tests/email-attributes.test.ts
@@ -70,6 +70,27 @@ describe('email attribute configuration (postguard#236)', () => {
     expect(body.con[0]).toEqual({ t: TEST_ATTRS.email, v: 'sender@example.com' });
   });
 
+  it('api-key signing requests carry the configured email type on the wire', async () => {
+    const { resolveSigningKeysFromApiKey } = await import('../src/signing/api-key.js');
+
+    let capturedBody: unknown;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return new Response(
+        JSON.stringify({ status: 'DONE', proofStatus: 'VALID', pubSignKey: { key: 'k', policy: { ts: 1, con: [] } } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }) as typeof fetch;
+    try {
+      await resolveSigningKeysFromApiKey('http://pkg.test', 'PG-key', undefined, TEST_ATTRS);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect((capturedBody as { pubSignId: { t: string }[] }).pubSignId[0].t).toBe(TEST_ATTRS.email);
+  });
+
   it('without overrides, everything keeps the production types', () => {
     const alice = new RecipientBuilder('alice@example.com', 'email');
     const policy = buildEncryptionPolicy([alice], 1);

--- a/tests/email-attributes.test.ts
+++ b/tests/email-attributes.test.ts
@@ -1,0 +1,81 @@
+// postguard#236: the email attribute types are configurable so test
+// environments (which cannot issue pbdf credentials) can run the identical
+// code paths under a test scheme. Defaults must remain the production pbdf
+// types — existing callers are unaffected.
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_EMAIL_ATTRIBUTES,
+  resolveEmailAttributes,
+} from '../src/util/attributes.js';
+import { buildEncryptionPolicy } from '../src/recipients/builders.js';
+import { buildKeyRequest } from '../src/util/policy.js';
+import { buildStartRequestBody } from '../src/signing/yivi.js';
+import { RecipientBuilder } from '../src/recipients/builder.js';
+
+const TEST_ATTRS = {
+  email: 'irma-demo.sidn-pbdf.email.email',
+  domain: 'irma-demo.sidn-pbdf.email.domain',
+};
+
+describe('email attribute configuration (postguard#236)', () => {
+  it('defaults to the production pbdf types', () => {
+    expect(resolveEmailAttributes()).toEqual(DEFAULT_EMAIL_ATTRIBUTES);
+    expect(DEFAULT_EMAIL_ATTRIBUTES.email).toBe('pbdf.sidn-pbdf.email.email');
+    expect(DEFAULT_EMAIL_ATTRIBUTES.domain).toBe('pbdf.sidn-pbdf.email.domain');
+  });
+
+  it('merges partial overrides with defaults', () => {
+    const attrs = resolveEmailAttributes({ email: TEST_ATTRS.email });
+    expect(attrs.email).toBe(TEST_ATTRS.email);
+    expect(attrs.domain).toBe(DEFAULT_EMAIL_ATTRIBUTES.domain);
+  });
+
+  it('recipient policies use the configured types', () => {
+    const alice = new RecipientBuilder('alice@example.com', 'email');
+    const anyCorp = new RecipientBuilder('bob@corp.example', 'emailDomain');
+
+    const policy = buildEncryptionPolicy([alice, anyCorp], 1234, TEST_ATTRS);
+
+    expect(policy['alice@example.com'].con).toEqual([
+      { t: TEST_ATTRS.email, v: 'alice@example.com' },
+    ]);
+    expect(policy['bob@corp.example'].con).toEqual([
+      { t: TEST_ATTRS.domain, v: 'corp.example' },
+    ]);
+  });
+
+  it('key requests pin the recipient value on the configured email type', () => {
+    const policy = {
+      ts: 1234,
+      con: [
+        { t: TEST_ATTRS.email },
+        { t: 'irma-demo.gemeente.personalData.fullname', v: 'should-be-stripped' },
+      ],
+    };
+
+    const req = buildKeyRequest('alice@example.com', policy, TEST_ATTRS);
+
+    const email = req.con.find((c) => c.t === TEST_ATTRS.email);
+    expect(email?.v).toBe('alice@example.com');
+    const other = req.con.find((c) => c.t !== TEST_ATTRS.email);
+    expect(other?.v).toBeUndefined();
+  });
+
+  it('yivi signing start requests prepend the configured email type', () => {
+    const body = buildStartRequestBody({
+      element: '#x',
+      senderEmail: 'sender@example.com',
+      emailAttributes: TEST_ATTRS,
+    });
+    expect(body.con[0]).toEqual({ t: TEST_ATTRS.email, v: 'sender@example.com' });
+  });
+
+  it('without overrides, everything keeps the production types', () => {
+    const alice = new RecipientBuilder('alice@example.com', 'email');
+    const policy = buildEncryptionPolicy([alice], 1);
+    expect(policy['alice@example.com'].con[0].t).toBe('pbdf.sidn-pbdf.email.email');
+
+    const body = buildStartRequestBody({ element: '#x' });
+    expect(body.con[0].t).toBe('pbdf.sidn-pbdf.email.email');
+  });
+});


### PR DESCRIPTION
Part 3 of encryption4all/postguard#236 (Phase 2 of EPIC encryption4all/postguard#201) — the pg-js leg; companions: encryption4all/postguard#244 (PKG, merged pending) and encryption4all/cryptify#193.

**Problem:** `pbdf.sidn-pbdf.email.{email,domain}` was hardcoded in 10 places across 6 files (recipient builders, key requests, decryption hints, `includeSender` policies, yivi/session signing bodies). No test environment can issue `pbdf.*` credentials, so the real SDK could never be driven end to end in a test — the single blocker to Phase 2's real-SDK harness flows.

**Change:** `new PostGuard({ …, emailAttributes: { email, domain } })` — resolved once against the production defaults and threaded through both pipelines and all signing/decrypt paths. **Zero behavior change without the option**: all 212 existing tests pass untouched.

The e2e stack will set `irma-demo.sidn-pbdf.email.email` (the public demo scheme mirrors the email credential with published issuer keys), matching the PKG's `PKG_EMAIL_ATTRIBUTE` and cryptify's `email_attribute`.

Notes:
- The JWT sender-email extraction heuristic (`.endsWith('.email.email')`) already matches demo-scheme types — untouched.
- 6 new tests (`tests/email-attributes.test.ts`) pin default + override behavior through builders, key requests and signing start bodies.
- `tsc --noEmit` clean, build clean, 218/218 tests.