### PR TITLE
fix: floor the seal policy timestamp so it is never in the future

### DIFF
--- a/src/crypto/encrypt.ts
+++ b/src/crypto/encrypt.ts
@@ -7,6 +7,7 @@ import { DEFAULT_EMAIL_ATTRIBUTES, type EmailAttributes } from '../util/attribut
 import { resolveSigningKeys } from './signing.js';
 import Chunker, { withTransform } from './chunker.js';
 import { createZipReadable } from '../util/zip.js';
+import { nowSeconds } from '../util/policy.js';
 import { loadWasm } from '../util/wasm.js';
 import type { RetryOptions } from '../util/retry.js';
 
@@ -59,7 +60,7 @@ export async function encryptPipeline(options: EncryptPipelineOptions): Promise<
   ]);
 
   // Build encryption policy
-  const ts = Math.round(Date.now() / 1000);
+  const ts = nowSeconds();
   const policy = buildEncryptionPolicy(recipients, ts, emailAttrs);
 
   // If the sign method requests including the sender, add a sender entry
@@ -186,7 +187,7 @@ export async function sealRaw(options: SealRawOptions): Promise<Uint8Array> {
   ]);
 
   // Build encryption policy
-  const ts = Math.round(Date.now() / 1000);
+  const ts = nowSeconds();
   const policy = buildEncryptionPolicy(recipients, ts, emailAttrs);
 
   // Include sender in policy if requested

--- a/src/util/policy.ts
+++ b/src/util/policy.ts
@@ -3,6 +3,17 @@ export function sortPolicies(con: { t: string; v?: string }[]): { t: string; v?:
   return [...con].sort((a, b) => a.t.localeCompare(b.t));
 }
 
+/** Current Unix time in whole seconds.
+ *
+ * Uses `floor`, never `round`: this stamps the policy timestamp a sealed
+ * container is keyed on, and the PKG rejects a USK request whose timestamp is
+ * in the future ("chronology error"). `Math.round` can land up to ~1s ahead of
+ * the real time, so an immediate decrypt (encrypt→decrypt within the same
+ * second) could fail; `floor` is always ≤ now. */
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 /** Calculate seconds until 4 AM (PKG key validity period) */
 export function secondsTill4AM(): number {
   const now = Date.now();

--- a/tests/now-seconds.test.ts
+++ b/tests/now-seconds.test.ts
@@ -1,0 +1,29 @@
+// The seal policy timestamp must never be in the future: the PKG rejects a USK
+// request whose timestamp is > now ("chronology error"), so an immediate
+// encrypt→decrypt could fail if the timestamp were rounded up. nowSeconds()
+// uses floor for exactly this reason.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nowSeconds } from '../src/util/policy.js';
+
+describe('nowSeconds', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('floors — never rounds a sub-second past 0.5 up to the next second', () => {
+    // 1000.700s: Math.round would give 1001 (one second in the future).
+    vi.setSystemTime(new Date(1000_700));
+    expect(nowSeconds()).toBe(1000);
+  });
+
+  it('is exact on a whole second', () => {
+    vi.setSystemTime(new Date(1000_000));
+    expect(nowSeconds()).toBe(1000);
+  });
+
+  it('never exceeds Date.now()/1000 (would trip the PKG chronology check)', () => {
+    for (const ms of [1234_001, 1234_499, 1234_500, 1234_999]) {
+      vi.setSystemTime(new Date(ms));
+      expect(nowSeconds()).toBeLessThanOrEqual(Date.now() / 1000);
+    }
+  });
+});


### PR DESCRIPTION
The PKG rejects a USK request whose timestamp is `> now` ("chronology error"). The seal policy timestamp was stamped with `Math.round(Date.now() / 1000)`, which can land up to **~1 second in the future** — so an encrypt→decrypt within the same second can fail.

In normal usage the multi-second encrypt→decrypt gap masks this, which is why it's gone unnoticed. The e2e harness (encryption4all/postguard-e2e#15) runs the full flow headless in <1s and surfaced it: `decrypt` failed with `[http 400] {"error":true,"message":"chronology error"}`.

**Fix:** extract `nowSeconds()` (uses `Math.floor`, always ≤ now) and use it for both seal timestamps (`encryptPipeline` + `sealRaw`). Adds unit tests pinning the floor behavior (a sub-second past 0.5 must not round up to the next second).

No wire-format or API change — the timestamp is already wall-clock-derived; this only removes the ≤1s forward skew.
