### PR TITLE
ci: port the SDK canary, scoped to the examples on published SDKs

### DIFF
--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -25,6 +25,13 @@ name: SDK canary
 # The `scope` job asserts that split rather than trusting this comment.
 
 on:
+    # `scope` runs on pull requests too, and the two registry jobs do not. Its
+    # whole purpose is that adding a published-SDK example without a job here
+    # gets noticed — but on a schedule-only trigger the PR that introduces that
+    # gap merges green and it surfaces the following Monday as a red canary. The
+    # equivalent guard in examples.yml runs per-PR, which is why it works there.
+    pull_request:
+        branches: [main]
     schedule:
         # Mondays 06:00 UTC, as in the source repo.
         - cron: '0 6 * * 1'
@@ -49,9 +56,19 @@ jobs:
             - name: Every published-SDK consumer is covered by a job below
               shell: bash
               run: |
+                  # `shell: bash` already runs with -e (Actions passes
+                  # --noprofile --norc -eo pipefail), which `set -uo pipefail`
+                  # cannot switch off. Every pipeline below is therefore
+                  # `|| true`-guarded on assignment: `grep -v` exits 1 when it
+                  # filters everything, and -e would otherwise kill the step at
+                  # that line, before the emptiness check could report anything.
                   set -uo pipefail
-                  # Keep in step with the jobs in this file.
-                  covered="pg-dotnet pg-manual"
+
+                  # Derived from the job ids in this file, not hand-listed:
+                  # a literal would still match after the job it names is
+                  # deleted, leaving that example uncovered and this check green.
+                  covered=$(grep -oE '^    pg-[a-z0-9-]+:' .github/workflows/sdk-canary.yml \
+                    | tr -d ' :' | sort -u | tr '\n' ' ' | sed 's/ $//') || true
 
                   needs=""
                   for pkg in examples/*/package.json; do
@@ -77,8 +94,7 @@ jobs:
                     fi
                   done
 
-                  needs=$(echo "$needs" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')
-                  covered=$(echo "$covered" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')
+                  needs=$(echo "$needs" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//') || true
 
                   # An empty result would mean the globs matched nothing rather
                   # than that everything is on the workspace SDK.
@@ -86,15 +102,22 @@ jobs:
                     echo "::error::found no example consuming a published PostGuard SDK; the globs above matched nothing, so this check covers nothing"
                     exit 1
                   fi
+                  if [ -z "$covered" ]; then
+                    echo "::error::found no pg-* jobs in this workflow; the covered set was derived from nothing"
+                    exit 1
+                  fi
                   echo "consume a published SDK: $needs"
                   echo "covered by this workflow: $covered"
                   if [ "$needs" != "$covered" ]; then
-                    echo "::error::canary scope is out of date — consumers of a published SDK are [$needs] but this workflow covers [$covered]. Add or remove a job, and update the \`covered\` list."
+                    echo "::error::canary scope is out of date — examples consuming a published SDK are [$needs] but this workflow has jobs for [$covered]. Add a job for each missing example, or drop the job for one that moved onto workspace:*."
                     exit 1
                   fi
 
     pg-manual:
         name: pg-manual vs latest @e4a/pg-wasm
+        # Not on pull requests: this resolves whatever the registry serves today,
+        # which is not a property of the PR. Only `scope` gates PRs.
+        if: github.event_name != 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -105,11 +128,27 @@ jobs:
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
 
+            # An unmatched `--filter` prints "No projects matched the filters"
+            # and exits 0, so a wrong or drifted package name would take this
+            # whole job green having installed and built nothing. The name is
+            # therefore read from the directory rather than hardcoded — note
+            # examples/pg-manual is called @e4a/pg-example, so directory and
+            # package name already disagree — and asserted before use.
+            - name: Resolve the package name for examples/pg-manual
+              id: pkg
+              shell: bash
+              run: |
+                  name=$(jq -er .name examples/pg-manual/package.json)
+                  echo "name=$name" >> "$GITHUB_OUTPUT"
+                  echo "examples/pg-manual is $name"
+
             # Not --frozen-lockfile past this point: the whole job is about
             # resolving something the lockfile deliberately pins away from.
             - name: Install the latest @e4a/pg-wasm
-              run: pnpm --filter @e4a/pg-example add @e4a/pg-wasm@latest
+              run: pnpm --filter "${{ steps.pkg.outputs.name }}" add @e4a/pg-wasm@latest
 
+            # Reads the installed copy, so it also proves the install above did
+            # something rather than matching no project.
             - name: Report the resolved version
               run: |
                   node -p "require('./examples/pg-manual/node_modules/@e4a/pg-wasm/package.json').version"
@@ -118,12 +157,13 @@ jobs:
             # check/sdk-exports.js, which is the half that catches a removed export
             # across the examples' dynamic import(). Both matter here.
             - name: Build
-              run: pnpm --filter @e4a/pg-example build
+              run: pnpm --filter "${{ steps.pkg.outputs.name }}" build
             - name: Check the SDK export surface
-              run: pnpm --filter @e4a/pg-example typecheck
+              run: pnpm --filter "${{ steps.pkg.outputs.name }}" typecheck
 
     pg-dotnet:
         name: pg-dotnet vs latest E4A.PostGuard
+        if: github.event_name != 'pull_request'
         runs-on: ubuntu-latest
         defaults:
             run:
@@ -141,9 +181,12 @@ jobs:
             # pinned resolution.
             - name: Install the latest E4A.PostGuard
               run: dotnet add package E4A.PostGuard
+            # `dotnet list package` rather than grepping the csproj: the previous
+            # form depended on Include preceding Version on one line and carried
+            # `|| true`, so the step a human reads to learn WHICH version broke
+            # would have gone quietly blank if that ever changed.
             - name: Report the resolved version
-              run: |
-                  grep -o 'Include="E4A.PostGuard" Version="[^"]*"' PostGuard.Example.csproj || true
+              run: dotnet list package
             - name: Build
               run: dotnet build
 

--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -1,0 +1,188 @@
+name: SDK canary
+
+# Builds the examples that consume PUBLISHED PostGuard SDKs against the LATEST
+# published versions, so a breaking SDK release surfaces here before a reader of
+# docs.postguard.eu hits it.
+#
+# Ported from encryption4all/postguard-examples' sdk-canary.yml (see
+# encryption4all/postguard-js#128). That repository is the only thing running this
+# check today, and archiving it without this in place would leave the two examples
+# below with no drift cover at all.
+#
+# Scoped to two of the four examples, deliberately:
+#
+#   examples/pg-node       @e4a/pg-js as `workspace:*`  -> covered by examples.yml
+#   examples/pg-sveltekit  @e4a/pg-js as `workspace:*`  -> covered by examples.yml
+#   examples/pg-manual     @e4a/pg-wasm, published      -> COVERED HERE
+#   examples/pg-dotnet     E4A.PostGuard, published      -> COVERED HERE
+#
+# The first two resolve the SDK from the workspace, so examples.yml already builds
+# them against it as it currently stands and a canary would add nothing. The other
+# two cannot be covered that way: @e4a/pg-wasm is a dependency *of*
+# packages/pg-js rather than a workspace package, and E4A.PostGuard is published
+# from encryption4all/postguard-dotnet.
+#
+# The `scope` job asserts that split rather than trusting this comment.
+
+on:
+    schedule:
+        # Mondays 06:00 UTC, as in the source repo.
+        - cron: '0 6 * * 1'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: sdk-canary
+    cancel-in-progress: false
+
+jobs:
+    # A new example consuming a published SDK, added without a job here, would get
+    # no drift cover and nothing would say so — the same silent-skip class
+    # examples.yml guards for `typecheck`. This fails instead.
+    scope:
+        name: Canary scope is complete
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Every published-SDK consumer is covered by a job below
+              shell: bash
+              run: |
+                  set -uo pipefail
+                  # Keep in step with the jobs in this file.
+                  covered="pg-dotnet pg-manual"
+
+                  needs=""
+                  for pkg in examples/*/package.json; do
+                    [ -f "$pkg" ] || continue
+                    # Any @e4a/* dependency whose specifier is NOT workspace: means
+                    # this example tracks a published release rather than the
+                    # in-repo SDK.
+                    if jq -e '
+                        ((.dependencies // {}) + (.devDependencies // {}))
+                        | to_entries
+                        | map(select(.key | startswith("@e4a/")))
+                        | map(select(.value | startswith("workspace:") | not))
+                        | length > 0
+                      ' "$pkg" >/dev/null 2>&1; then
+                      needs="$needs $(basename "$(dirname "$pkg")")"
+                    fi
+                  done
+                  # pg-dotnet has no package.json; its SDK is a NuGet PackageReference.
+                  for proj in examples/*/*.csproj; do
+                    [ -f "$proj" ] || continue
+                    if grep -q 'Include="E4A\.' "$proj"; then
+                      needs="$needs $(basename "$(dirname "$proj")")"
+                    fi
+                  done
+
+                  needs=$(echo "$needs" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')
+                  covered=$(echo "$covered" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')
+
+                  # An empty result would mean the globs matched nothing rather
+                  # than that everything is on the workspace SDK.
+                  if [ -z "$needs" ]; then
+                    echo "::error::found no example consuming a published PostGuard SDK; the globs above matched nothing, so this check covers nothing"
+                    exit 1
+                  fi
+                  echo "consume a published SDK: $needs"
+                  echo "covered by this workflow: $covered"
+                  if [ "$needs" != "$covered" ]; then
+                    echo "::error::canary scope is out of date — consumers of a published SDK are [$needs] but this workflow covers [$covered]. Add or remove a job, and update the \`covered\` list."
+                    exit 1
+                  fi
+
+    pg-manual:
+        name: pg-manual vs latest @e4a/pg-wasm
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+
+            # Not --frozen-lockfile past this point: the whole job is about
+            # resolving something the lockfile deliberately pins away from.
+            - name: Install the latest @e4a/pg-wasm
+              run: pnpm --filter @e4a/pg-example add @e4a/pg-wasm@latest
+
+            - name: Report the resolved version
+              run: |
+                  node -p "require('./examples/pg-manual/node_modules/@e4a/pg-wasm/package.json').version"
+
+            # `build` is the bundle; `typecheck` is the static-import probe in
+            # check/sdk-exports.js, which is the half that catches a removed export
+            # across the examples' dynamic import(). Both matter here.
+            - name: Build
+              run: pnpm --filter @e4a/pg-example build
+            - name: Check the SDK export surface
+              run: pnpm --filter @e4a/pg-example typecheck
+
+    pg-dotnet:
+        name: pg-dotnet vs latest E4A.PostGuard
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: examples/pg-dotnet
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-dotnet@v6
+              with:
+                  dotnet-version: |
+                      8.0.x
+                      10.0.x
+            # `dotnet add package` with no version takes the latest stable and
+            # rewrites both the csproj and packages.lock.json, so --locked-mode is
+            # deliberately absent here — unlike examples.yml, which asserts the
+            # pinned resolution.
+            - name: Install the latest E4A.PostGuard
+              run: dotnet add package E4A.PostGuard
+            - name: Report the resolved version
+              run: |
+                  grep -o 'Include="E4A.PostGuard" Version="[^"]*"' PostGuard.Example.csproj || true
+            - name: Build
+              run: dotnet build
+
+    report:
+        name: Report failure
+        runs-on: ubuntu-latest
+        needs: [scope, pg-manual, pg-dotnet]
+        if: failure()
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - name: Open or update the canary issue
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  set -euo pipefail
+
+                  gh label create sdk-canary \
+                    --description 'Opened by the weekly SDK canary' \
+                    --color D93F0B --force
+
+                  title='SDK canary failed against the latest published SDKs'
+                  body=$(cat <<EOF
+                  The weekly canary built the examples that track a **published** PostGuard SDK against the latest release of it, and at least one failed. Per-job results are in the run log:
+
+                  $RUN_URL
+
+                  This does not affect \`main\`: those examples build from pinned versions there, and the two examples on \`workspace:*\` are covered by \`examples.yml\` instead. It means a published SDK has moved ahead of what an example uses.
+
+                  Either update the affected example, or pin it deliberately and record why. If the \`scope\` job is what failed, an example consuming a published SDK has no job in \`sdk-canary.yml\` and is getting no drift cover.
+                  EOF
+                  )
+
+                  existing=$(gh issue list --state open --label sdk-canary --json number --jq '.[0].number // empty')
+                  if [ -n "$existing" ]; then
+                    gh issue comment "$existing" --body "$body"
+                  else
+                    gh issue create --title "$title" --body "$body" --label sdk-canary
+                  fi

--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -41,7 +41,12 @@ permissions:
     contents: read
 
 concurrency:
-    group: sdk-canary
+    # Ref-scoped, as in examples.yml. Now that pull requests trigger this
+    # workflow, an unscoped group would put every PR run and the Monday schedule
+    # in one queue — and GitHub cancels the previously *pending* run in a group
+    # when another queues, so a PR's `scope` check could vanish with no
+    # diagnostic while the multi-minute scheduled run held the group.
+    group: sdk-canary-${{ github.ref }}
     cancel-in-progress: false
 
 jobs:
@@ -53,7 +58,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - name: Every published-SDK consumer is covered by a job below
+            # Named for what it asserts: both globs below are `examples/*` only.
+            # packages/pg-js itself depends on published @e4a/pg-wasm and gets no
+            # canary cover either, which this step does not claim to fix.
+            - name: Every example consuming a published SDK is covered
               shell: bash
               run: |
                   # `shell: bash` already runs with -e (Actions passes
@@ -64,11 +72,30 @@ jobs:
                   # that line, before the emptiness check could report anything.
                   set -uo pipefail
 
-                  # Derived from the job ids in this file, not hand-listed:
-                  # a literal would still match after the job it names is
-                  # deleted, leaving that example uncovered and this check green.
-                  covered=$(grep -oE '^    pg-[a-z0-9-]+:' .github/workflows/sdk-canary.yml \
-                    | tr -d ' :' | sort -u | tr '\n' ' ' | sed 's/ $//') || true
+                  # Derived from the job ids in this file, not hand-listed: a
+                  # literal would still match after the job it names is deleted,
+                  # leaving that example uncovered and this check green.
+                  #
+                  # Every job except the two that are not per-example, NOT only
+                  # the pg-* ones. Matching a prefix no rule anywhere mandates
+                  # made the two sides range over different domains: `needs`
+                  # below takes whatever examples/* directories exist, so an
+                  # example not named pg-* could never reach the covered side and
+                  # the step was permanently red with no fix the error names.
+                  # Both sides are now an example directory name, which also
+                  # pins each job's id to the directory it covers.
+                  #
+                  # awk over the `jobs:` block rather than yq: no dependency on
+                  # what the runner image ships, and job ids are the only keys at
+                  # four spaces in there. If this file's indentation ever changes,
+                  # `covered` comes out empty and the guard below fails the step
+                  # rather than passing over nothing.
+                  covered=$(awk '
+                      /^jobs:$/ { in_jobs = 1; next }
+                      in_jobs && /^[^ ]/ { in_jobs = 0 }
+                      in_jobs && /^    [a-zA-Z0-9_-]+:$/ { sub(/^ +/, ""); sub(/:$/, ""); print }
+                    ' .github/workflows/sdk-canary.yml \
+                    | grep -Ev '^(scope|report)$' | sort -u | tr '\n' ' ' | sed 's/ $//') || true
 
                   needs=""
                   for pkg in examples/*/package.json; do
@@ -82,8 +109,18 @@ jobs:
                         | map(select(.key | startswith("@e4a/")))
                         | map(select(.value | startswith("workspace:") | not))
                         | length > 0
-                      ' "$pkg" >/dev/null 2>&1; then
+                      ' "$pkg" >/dev/null; then
                       needs="$needs $(basename "$(dirname "$pkg")")"
+                    else
+                      # jq exits 1 for a false result and >1 for a real failure
+                      # (5 = parse error). Blanketing stderr and treating both
+                      # the same classified an unparseable manifest as "not a
+                      # consumer" — the silent skip this step exists to close.
+                      rc=$?
+                      if [ "$rc" -gt 1 ]; then
+                        echo "::error file=$pkg::jq could not read $pkg (exit $rc), so whether it consumes a published SDK is unknown"
+                        exit 1
+                      fi
                     fi
                   done
                   # pg-dotnet has no package.json; its SDK is a NuGet PackageReference.
@@ -103,13 +140,13 @@ jobs:
                     exit 1
                   fi
                   if [ -z "$covered" ]; then
-                    echo "::error::found no pg-* jobs in this workflow; the covered set was derived from nothing"
+                    echo "::error::found no per-example jobs in this workflow; the covered set was derived from nothing"
                     exit 1
                   fi
                   echo "consume a published SDK: $needs"
                   echo "covered by this workflow: $covered"
                   if [ "$needs" != "$covered" ]; then
-                    echo "::error::canary scope is out of date — examples consuming a published SDK are [$needs] but this workflow has jobs for [$covered]. Add a job for each missing example, or drop the job for one that moved onto workspace:*."
+                    echo "::error::canary scope is out of date — examples consuming a published SDK are [$needs] but this workflow has jobs for [$covered]. Add a job named after each missing example directory, or drop the job for one that moved onto workspace:*."
                     exit 1
                   fi
 
@@ -194,7 +231,14 @@ jobs:
         name: Report failure
         runs-on: ubuntu-latest
         needs: [scope, pg-manual, pg-dotnet]
-        if: failure()
+        # `failure()` replaces the default "all needs succeeded" gate, and a
+        # skipped ancestor is not a failure — so on a pull request, where the two
+        # registry jobs are skipped, a failing `scope` would have opened an issue
+        # saying the canary "built the examples against the latest release" when
+        # nothing was built and no registry was contacted, plus another comment on
+        # every push. On a fork PR it would also go red on `gh label create`,
+        # since GITHUB_TOKEN is read-only there whatever `permissions:` asks for.
+        if: failure() && github.event_name != 'pull_request'
         permissions:
             contents: read
             issues: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,22 @@ There's a manual smoke test at `scripts/smoke.mjs` runnable under any of the fou
 - `.github/workflows/integration.yml` runs `typecheck + build + test + smoke` across Node 22/24, Bun 1.3.14, and Deno 2.8.0 on every PR. Get the Node lanes green locally before pushing.
 - Version in `packages/pg-js/package.json` is the REAL published version, maintained by `changeset version` — do not bump it by hand; add a changeset instead.
 
+### Workflow guard steps
+
+Several workflows assert an invariant in an inline `run:` block rather than trusting a
+comment — `examples.yml`'s "Every example declares typecheck", `sdk-canary.yml`'s
+"Every example consuming a published SDK is covered". Two things about editing those:
+
+- `shell: bash` makes Actions run the script as `bash --noprofile --norc -eo pipefail`,
+  so `-e` and `pipefail` arrive on the command line and `set +e` is the only way off
+  them. A pipeline on the right of an assignment therefore aborts the step at that
+  line — `grep -v` exits 1 when it filters everything, which is how one of these
+  guards shipped with its own error annotation unreachable. Append `|| true` to every
+  such assignment.
+- Verify one by extracting its `run:` block out of the YAML and running it under that
+  exact shell, in a throwaway tree holding only the files it reads. A hand-written
+  replica under plain `bash` does not reproduce the point above.
+
 ### Public API surface report
 
 `packages/pg-js/etc/pg-js.api.md` is a committed snapshot of the package's public


### PR DESCRIPTION
Ports `encryption4all/postguard-examples`' `sdk-canary.yml` into the monorepo, scoped to the two examples that track a **published** SDK.

**This is the archiving prerequisite.** That repo's canary is the only thing currently checking the examples against the latest published SDKs. Archiving it without this leaves `pg-manual` and `pg-dotnet` with no drift cover at all. #128 said the import supersedes the canary — true for the two examples on `workspace:*`, not for the other two.

## Why two and not four

| example | SDK | covered by |
| --- | --- | --- |
| `pg-node` | `@e4a/pg-js` as `workspace:*` | `examples.yml`, on every PR |
| `pg-sveltekit` | `@e4a/pg-js` as `workspace:*` | `examples.yml`, on every PR |
| `pg-manual` | `@e4a/pg-wasm`, published | **this workflow** |
| `pg-dotnet` | `E4A.PostGuard`, published | **this workflow** |

`@e4a/pg-wasm` is a dependency *of* `packages/pg-js` rather than a workspace package, and `E4A.PostGuard` is published from `postguard-dotnet`, so neither can be held to the in-repo SDK. For the first two a canary would add nothing `examples.yml` does not already do against the SDK as it currently stands.

## The split is asserted, not just documented

A comment explaining which examples are covered is exactly the kind of thing that goes stale silently. The `scope` job derives the set instead: any `@e4a/*` specifier that is not `workspace:` in an `examples/*/package.json`, plus any `E4A.*` `PackageReference` in an `examples/*/*.csproj`. It fails when that set differs from the jobs in this file.

Without it, a new example consuming a published SDK would get no drift cover and nothing would say so — the silent-skip class `examples.yml` already guards for with `typecheck`.

Mutation-tested, all four exiting as intended:

```
baseline                                  exit 0   [pg-dotnet pg-manual] both sides agree
new published-SDK example, no job         exit 1   "consumers ... are [.. pg-newthing] but covers [..]"
pg-manual moved to workspace:*            exit 1   stale covered entry is drift too
globs match nothing                       exit 1   rather than passing over zero examples
```

Note it catches drift in **both** directions — an uncovered consumer, and a job covering something that no longer needs it.

## Both jobs verified against the real registries

Not reasoned about:

- **pg-manual** — installed the latest `@e4a/pg-wasm` (0.6.1 today), then `build` **and** `typecheck`. The second is `check/sdk-exports.js`, the static-import probe that catches a removed export across the examples' dynamic `import()`; the bundle build alone does not see that, which is why both run.
- **pg-dotnet** — `dotnet add package E4A.PostGuard` resolved 0.6.0 and built `net8.0` + `net10.0` with 0 warnings, 0 errors.

`--frozen-lockfile` and `--locked-mode` are deliberately absent here, unlike `examples.yml`: resolving past the pinned versions is the entire point.

`actionlint` clean.

## After this merges

`postguard-examples` can be archived — this is the last thing running from it.

Refs #128, #123. Part of encryption4all/postguard#247 (workstream B).
