### PR TITLE
fix: stop changeset version silently dropping CHANGELOGs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,11 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": [
+    "@e4a/pg-example",
+    "pg-node",
+    "pg-sveltekit"
+  ],
   "privatePackages": {
     "version": true,
     "tag": false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,13 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            # Cheap, and it guards a failure that already shipped unnoticed: a
+            # prettier plugin a package declares but the root does not install
+            # makes `changeset version` drop that package's CHANGELOG silently,
+            # while still exiting 0. See scripts/check-prettier-plugins.mjs.
+            - name: Prettier plugins resolve from the root
+              run: pnpm check-prettier-plugins
+
             - name: Typecheck
               run: pnpm -r typecheck
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ All commands from the repo root unless noted; root `build`/`test`/`typecheck` ar
 | Run a single test file       | `pnpm exec vitest run tests/api.test.ts` (in `packages/pg-js`) |
 | Run a single test by name    | `pnpm exec vitest run -t "name fragment"` (in `packages/pg-js`) |
 | Refresh the API report       | `pnpm api:update` (in `packages/pg-js`, after a build) |
+| Check prettier plugin resolution | `pnpm check-prettier-plugins` |
 
 ### Prebuild generators (important)
 
@@ -85,6 +86,7 @@ There's a manual smoke test at `scripts/smoke.mjs` runnable under any of the fou
 - `main` is the release branch. Releases are managed by **changesets** (`.github/workflows/delivery.yml`): a PR that should ship adds a changeset file (`pnpm changeset`); merging to main opens/updates a "Version Packages" PR; merging THAT publishes to npm with provenance. PR titles must still follow Conventional Commits — `.github/workflows/pr-title.yml` enforces this via `action-semantic-pull-request`.
 - `.github/workflows/integration.yml` runs `typecheck + build + test + smoke` across Node 22/24, Bun 1.3.14, and Deno 2.8.0 on every PR. Get the Node lanes green locally before pushing.
 - Version in `packages/pg-js/package.json` is the REAL published version, maintained by `changeset version` — do not bump it by hand; add a changeset instead.
+- **Every prettier plugin a workspace member declares must ALSO be a root `devDependency`.** `changeset version` formats each `CHANGELOG.md` through prettier, resolving the owning package's config but loading its plugins from the *process cwd* — the repo root. A plugin missing there makes changesets throw while writing that changelog, catch it, print the stack, and **still exit 0 with "All files have been updated"**: the version bump lands, the changelog entry silently does not. `apps/website` did this on every release from its import until it was found, because the gap is invisible in normal use — the app's own `pnpm lint` resolves the plugin fine from its own `node_modules`. `pnpm check-prettier-plugins` asserts it, runs in `integration.yml`, and gates `version-packages` ahead of `changeset version`. When it reports a plugin missing, add it to the ROOT `package.json`, not to the app that declares it.
 
 ### Public API surface report
 

--- a/examples/pg-node/package.json
+++ b/examples/pg-node/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "PostGuard Node.js example \u2014 encrypt + upload from a server",
+  "description": "PostGuard Node.js example — encrypt + upload from a server",
   "license": "MIT",
   "scripts": {
     "start": "node --env-file-if-exists=.env index.mjs",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,16 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck",
+    "check-prettier-plugins": "node scripts/check-prettier-plugins.mjs",
     "changeset": "changeset",
-    "version-packages": "changeset version && pnpm --filter postguard-tb-addon sync-version && pnpm --filter postguard-outlook-addin sync-version",
+    "version-packages": "pnpm check-prettier-plugins && changeset version && pnpm --filter postguard-tb-addon sync-version && pnpm --filter postguard-outlook-addin sync-version",
     "release": "pnpm --filter @e4a/pg-js build && changeset publish",
     "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
-    "husky": "^9.1.7"
+    "husky": "^9.1.7",
+    "prettier": "^3.9.6",
+    "prettier-plugin-svelte": "^4.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,12 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      prettier-plugin-svelte:
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.9.6)(svelte@5.56.8(@typescript-eslint/types@8.65.0))
 
   apps/outlook-addon:
     dependencies:
@@ -12438,7 +12444,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.109.2(webpack-cli@7.2.2)
+      webpack: 5.109.2(postcss@8.5.23)(webpack-cli@7.2.2)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -15226,7 +15232,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.109.2(webpack-cli@7.2.2)
+      webpack: 5.109.2(postcss@8.5.23)(webpack-cli@7.2.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       js-yaml: 4.3.0
@@ -15242,7 +15248,7 @@ snapshots:
       range-parser: 1.3.0
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.109.2(webpack-cli@7.2.2)
+      webpack: 5.109.2(postcss@8.5.23)(webpack-cli@7.2.2)
     transitivePeerDependencies:
       - tslib
 
@@ -15277,7 +15283,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.109.2)
       ws: 8.21.1
     optionalDependencies:
-      webpack: 5.109.2(webpack-cli@7.2.2)
+      webpack: 5.109.2(postcss@8.5.23)(webpack-cli@7.2.2)
       webpack-cli: 7.2.2(js-yaml@4.3.0)(json5@2.2.3)(webpack-dev-server@5.2.6)(webpack@5.109.2)
     transitivePeerDependencies:
       - bufferutil

--- a/scripts/check-prettier-plugins.mjs
+++ b/scripts/check-prettier-plugins.mjs
@@ -1,0 +1,97 @@
+// Assert that every prettier plugin a workspace member declares resolves from
+// the repository root.
+//
+// This exists because of a failure that shipped silently. `changeset version`
+// formats each CHANGELOG.md through prettier, resolving the owning package's
+// prettier config but loading plugins from the *process* cwd — the repo root.
+// `apps/website` declares `prettier-plugin-svelte`, which was not installed
+// there, so writing its changelog threw `Cannot find package
+// 'prettier-plugin-svelte'`. changesets caught that, printed the stack, then
+// exited 0 with "All files have been updated".
+//
+// The result: the website's version was bumped on every release while its
+// CHANGELOG.md was never written, and nothing failed. A missing root plugin is
+// invisible in normal use — each package's own `pnpm lint` resolves it fine from
+// its own node_modules — so it needs asserting rather than observing.
+//
+// Run from the repository root: `node scripts/check-prettier-plugins.mjs`
+
+import { createRequire } from 'node:module'
+import { readdirSync, readFileSync } from 'node:fs'
+
+const require = createRequire(import.meta.url)
+
+const WORKSPACE_DIRS = ['apps', 'packages', 'examples']
+
+// readdirSync rather than fs.globSync: the latter is still experimental on Node
+// 22, which integration.yml covers alongside 24.
+function memberConfigFiles() {
+    const files = []
+    for (const dir of WORKSPACE_DIRS) {
+        let members
+        try {
+            members = readdirSync(dir, { withFileTypes: true })
+        } catch {
+            continue
+        }
+        for (const member of members) {
+            if (!member.isDirectory()) continue
+            // Both places prettier looks for a config in this workspace.
+            files.push(`${dir}/${member.name}/.prettierrc`)
+            files.push(`${dir}/${member.name}/package.json`)
+        }
+    }
+    return files
+}
+
+const declared = new Map() // plugin -> [declaring file, ...]
+
+for (const file of memberConfigFiles()) {
+    let parsed
+    try {
+        parsed = JSON.parse(readFileSync(file, 'utf8'))
+    } catch {
+        // Absent, or not JSON (a .prettierrc may be YAML or JS). Either way there
+        // is nothing to read here.
+        continue
+    }
+    // A package.json holds its prettier config under the `prettier` key; a
+    // .prettierrc is the config itself. A string `prettier` value is a shared
+    // config package, whose own plugins resolve relative to itself.
+    const config = file.endsWith('package.json') ? parsed.prettier : parsed
+    const plugins = config?.plugins
+    if (!Array.isArray(plugins)) continue
+    for (const plugin of plugins) {
+        if (typeof plugin !== 'string') continue
+        if (!declared.has(plugin)) declared.set(plugin, [])
+        declared.get(plugin).push(file)
+    }
+}
+
+if (declared.size === 0) {
+    // Nothing found means the directories above matched nothing, not that the
+    // workspace is clean — the same vacuous pass this script exists to prevent.
+    console.error(
+        `no prettier plugins declared under ${WORKSPACE_DIRS.join('/, ')}/ — nothing was ` +
+            'read, so this check covers nothing. Run it from the repository root.'
+    )
+    process.exit(1)
+}
+
+let failed = false
+for (const [plugin, files] of [...declared].sort()) {
+    try {
+        require.resolve(plugin)
+        console.log(`  ok       ${plugin}  (declared by ${files.join(', ')})`)
+    } catch {
+        failed = true
+        console.error(
+            `  MISSING  ${plugin}  (declared by ${files.join(', ')})\n` +
+                '           Add it to the root package.json devDependencies. Without it,\n' +
+                '           `changeset version` silently fails to write the CHANGELOG.md of\n' +
+                '           every package declaring it, and still exits 0.'
+        )
+    }
+}
+
+process.exit(failed ? 1 : 0)

--- a/scripts/check-prettier-plugins.mjs
+++ b/scripts/check-prettier-plugins.mjs
@@ -1,5 +1,5 @@
-// Assert that every prettier plugin a workspace member declares resolves from
-// the repository root.
+// Assert that every prettier plugin a workspace member declares can be resolved
+// from the repository root.
 //
 // This exists because of a failure that shipped silently. `changeset version`
 // formats each CHANGELOG.md through prettier, resolving the owning package's
@@ -14,84 +14,238 @@
 // invisible in normal use — each package's own `pnpm lint` resolves it fine from
 // its own node_modules — so it needs asserting rather than observing.
 //
+// Fail-closed throughout: a config this script cannot read is an error rather
+// than a skip, because a silent skip is the exact failure it exists to catch.
+//
 // Run from the repository root: `node scripts/check-prettier-plugins.mjs`
 
-import { createRequire } from 'node:module'
 import { readdirSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
-const require = createRequire(import.meta.url)
+const problems = []
+const notes = []
 
-const WORKSPACE_DIRS = ['apps', 'packages', 'examples']
-
-// readdirSync rather than fs.globSync: the latter is still experimental on Node
-// 22, which integration.yml covers alongside 24.
-function memberConfigFiles() {
-    const files = []
-    for (const dir of WORKSPACE_DIRS) {
-        let members
-        try {
-            members = readdirSync(dir, { withFileTypes: true })
-        } catch {
-            continue
-        }
-        for (const member of members) {
-            if (!member.isDirectory()) continue
-            // Both places prettier looks for a config in this workspace.
-            files.push(`${dir}/${member.name}/.prettierrc`)
-            files.push(`${dir}/${member.name}/package.json`)
-        }
-    }
-    return files
-}
-
-const declared = new Map() // plugin -> [declaring file, ...]
-
-for (const file of memberConfigFiles()) {
-    let parsed
-    try {
-        parsed = JSON.parse(readFileSync(file, 'utf8'))
-    } catch {
-        // Absent, or not JSON (a .prettierrc may be YAML or JS). Either way there
-        // is nothing to read here.
-        continue
-    }
-    // A package.json holds its prettier config under the `prettier` key; a
-    // .prettierrc is the config itself. A string `prettier` value is a shared
-    // config package, whose own plugins resolve relative to itself.
-    const config = file.endsWith('package.json') ? parsed.prettier : parsed
-    const plugins = config?.plugins
-    if (!Array.isArray(plugins)) continue
-    for (const plugin of plugins) {
-        if (typeof plugin !== 'string') continue
-        if (!declared.has(plugin)) declared.set(plugin, [])
-        declared.get(plugin).push(file)
-    }
-}
-
-if (declared.size === 0) {
-    // Nothing found means the directories above matched nothing, not that the
-    // workspace is clean — the same vacuous pass this script exists to prevent.
-    console.error(
-        `no prettier plugins declared under ${WORKSPACE_DIRS.join('/, ')}/ — nothing was ` +
-            'read, so this check covers nothing. Run it from the repository root.'
-    )
+// Single exit for unrecoverable setup errors, so a wrong working directory reads
+// as an instruction rather than a stack trace — this runs ahead of
+// `changeset version`, where a stack trace looks like a broken script.
+function fail(message) {
+    console.error(`prettier plugin check could not run: ${message}`)
     process.exit(1)
 }
 
-let failed = false
-for (const [plugin, files] of [...declared].sort()) {
+// --- which directories hold workspace members -------------------------------
+//
+// Derived from pnpm-workspace.yaml rather than hardcoded: a hand-kept list would
+// silently narrow this guard's coverage the day a new top-level workspace
+// directory is added, while it kept reporting ok.
+function workspaceDirs() {
+    let src
     try {
-        require.resolve(plugin)
+        src = readFileSync('pnpm-workspace.yaml', 'utf8')
+    } catch (err) {
+        fail(
+            err.code === 'ENOENT'
+                ? 'pnpm-workspace.yaml not found. Run this from the repository root.'
+                : `pnpm-workspace.yaml could not be read: ${err.message}`
+        )
+    }
+    const header = /^packages:[ \t]*$/m.exec(src)
+    if (!header) {
+        fail(
+            'pnpm-workspace.yaml has no top-level `packages:` list; this script cannot tell ' +
+                'which directories hold workspace members.'
+        )
+    }
+    const dirs = []
+    for (const line of src.slice(header.index + header[0].length).split('\n')) {
+        if (line.trim() === '' || /^\s*#/.test(line)) continue
+        const entry = /^\s+-\s*['"]?([^'"\s]+)['"]?\s*$/.exec(line)
+        if (!entry) break // first line that is neither a comment nor a list item
+        const pattern = entry[1]
+        // Only `<dir>/*` is understood. Anything else (a deeper glob, a bare
+        // path) is reported rather than quietly ignored.
+        const single = /^([^/*]+)\/\*$/.exec(pattern)
+        if (single) dirs.push(single[1])
+        else notes.push(`workspace pattern '${pattern}' is not of the form <dir>/*; not scanned`)
+    }
+    if (dirs.length === 0) {
+        fail('parsed pnpm-workspace.yaml but found no <dir>/* patterns to scan')
+    }
+    return dirs
+}
+
+// --- prettier config discovery ----------------------------------------------
+//
+// prettier reads more filenames than this script can parse. The ones it can are
+// listed here; the ones it cannot are detected and reported, because a config
+// that silently falls outside the guard is how the original bug survived.
+const PARSEABLE = ['.prettierrc', '.prettierrc.json', '.prettierrc.json5']
+const UNPARSEABLE = [
+    '.prettierrc.yml',
+    '.prettierrc.yaml',
+    '.prettierrc.js',
+    '.prettierrc.cjs',
+    '.prettierrc.mjs',
+    '.prettierrc.ts',
+    'prettier.config.js',
+    'prettier.config.cjs',
+    'prettier.config.mjs',
+    'prettier.config.ts',
+]
+
+function readJsonIfPresent(path) {
+    try {
+        return JSON.parse(readFileSync(path, 'utf8'))
+    } catch (err) {
+        if (err.code === 'ENOENT') return undefined
+        problems.push(`${path} exists but could not be parsed as JSON: ${err.message}`)
+        return undefined
+    }
+}
+
+// A `prettier` key holding a string names a shared config package, whose own
+// `plugins` are in scope here — prettier loads those from the process cwd like
+// any others, so an earlier version of this script was wrong to skip the string
+// form on the premise that they resolve relative to the config.
+//
+// The config *package* is a different matter: it resolves relative to the
+// declaring package.json, not the cwd. apps/outlook-addon's
+// office-addin-prettier-config is a devDependency of that app alone and is not
+// resolvable from the root, yet its CHANGELOG is written correctly — so
+// resolving it from the root here reported a failure that does not exist.
+async function pluginsFromSharedConfig(pkgName, declaringFile) {
+    let resolved
+    try {
+        resolved = createRequire(resolve(declaringFile)).resolve(pkgName)
+    } catch {
+        problems.push(
+            `${declaringFile} sets "prettier": "${pkgName}", which cannot be resolved from that ` +
+                'package, so its plugins cannot be checked'
+        )
+        return []
+    }
+    try {
+        const mod = await import(pathToFileURL(resolved).href)
+        const config = mod.default ?? mod
+        return Array.isArray(config?.plugins) ? config.plugins : []
+    } catch (err) {
+        problems.push(
+            `${declaringFile} sets "prettier": "${pkgName}" but importing it failed ` +
+                `(${err.message}), so its plugins cannot be checked`
+        )
+        return []
+    }
+}
+
+const dirs = workspaceDirs()
+const declared = new Map() // plugin specifier -> [declaring file, ...]
+let configsRead = 0
+
+function record(plugin, file) {
+    if (typeof plugin !== 'string') {
+        problems.push(`${file} declares a non-string plugin entry; not checked`)
+        return
+    }
+    if (!declared.has(plugin)) declared.set(plugin, [])
+    declared.get(plugin).push(file)
+}
+
+for (const dir of dirs) {
+    let members
+    try {
+        members = readdirSync(dir, { withFileTypes: true })
+    } catch {
+        problems.push(`workspace directory '${dir}' from pnpm-workspace.yaml could not be read`)
+        continue
+    }
+    for (const member of members) {
+        if (!member.isDirectory()) continue
+        const base = `${dir}/${member.name}`
+
+        for (const name of UNPARSEABLE) {
+            try {
+                readFileSync(`${base}/${name}`)
+                problems.push(
+                    `${base}/${name} is a prettier config this script cannot parse, so its ` +
+                        'plugins are unchecked. Convert it to JSON, or declare its plugins in ' +
+                        'the root package.json and handle the filename here.'
+                )
+            } catch {
+                /* absent, which is the normal case */
+            }
+        }
+
+        for (const name of PARSEABLE) {
+            const config = readJsonIfPresent(`${base}/${name}`)
+            if (!config) continue
+            configsRead++
+            if (Array.isArray(config.plugins)) {
+                for (const plugin of config.plugins) record(plugin, `${base}/${name}`)
+            }
+        }
+
+        const pkg = readJsonIfPresent(`${base}/package.json`)
+        if (!pkg) continue
+        configsRead++
+        if (typeof pkg.prettier === 'string') {
+            const plugins = await pluginsFromSharedConfig(pkg.prettier, `${base}/package.json`)
+            for (const plugin of plugins) {
+                record(plugin, `${base}/package.json (via ${pkg.prettier})`)
+            }
+        } else if (pkg.prettier && Array.isArray(pkg.prettier.plugins)) {
+            for (const plugin of pkg.prettier.plugins) record(plugin, `${base}/package.json`)
+        }
+    }
+}
+
+// Distinguish "read nothing" from "read everything, found no plugins". An
+// earlier version conflated them and told you to run from the repository root
+// even when it had read every config successfully — which, now that this gates
+// `changeset version`, would have misdirected the first release after a plugin
+// was legitimately dropped.
+if (configsRead === 0) {
+    fail(
+        `read no prettier or package configs under ${dirs.map((d) => `${d}/`).join(', ')} — ` +
+            'nothing was inspected.'
+    )
+}
+
+for (const [plugin, files] of [...declared].sort()) {
+    // A relative specifier is resolved by prettier against the config file, not
+    // the cwd, so the root has no bearing on it.
+    if (plugin.startsWith('.') || plugin.startsWith('/')) {
+        console.log(`  skip     ${plugin}  (relative path, resolved against ${files[0]})`)
+        continue
+    }
+    try {
+        // import.meta.resolve, not require.resolve: prettier imports plugins as
+        // ESM, so the `import` export condition is what applies. A plugin whose
+        // exports map is import-only resolves here but throws
+        // ERR_PACKAGE_PATH_NOT_EXPORTED under require.resolve, which would have
+        // failed the release claiming a correctly installed plugin was missing.
+        import.meta.resolve(plugin)
         console.log(`  ok       ${plugin}  (declared by ${files.join(', ')})`)
     } catch {
-        failed = true
-        console.error(
-            `  MISSING  ${plugin}  (declared by ${files.join(', ')})\n` +
-                '           Add it to the root package.json devDependencies. Without it,\n' +
-                '           `changeset version` silently fails to write the CHANGELOG.md of\n' +
-                '           every package declaring it, and still exits 0.'
+        problems.push(
+            `${plugin} is declared by ${files.join(', ')} but cannot be resolved from the ` +
+                'repository root. Add it to the ROOT package.json devDependencies — without ' +
+                'it, `changeset version` silently fails to write the CHANGELOG.md of every ' +
+                'package declaring it, and still exits 0.'
         )
     }
 }
 
-process.exit(failed ? 1 : 0)
+for (const note of notes) console.warn(`  note     ${note}`)
+
+if (problems.length > 0) {
+    console.error('\nprettier plugin check failed:')
+    for (const problem of problems) console.error(`  - ${problem}`)
+    process.exit(1)
+}
+
+console.log(
+    `\n${configsRead} configs inspected under ${dirs.map((d) => `${d}/`).join(', ')}; ` +
+        `${declared.size} distinct plugin(s), all resolvable from the root.`
+)


### PR DESCRIPTION
`apps/website` has been version-bumped **without a CHANGELOG entry on every release since it was imported**, and nothing reported it. From dobby's review of #145, which spotted the examples becoming a second instance of the same bug.

## The failure

`changeset version` formats each `CHANGELOG.md` through prettier. It resolves the owning package's prettier config, but loads plugins from the *process* cwd — the repository root. `apps/website` declares `prettier-plugin-svelte`; the root did not install it. So writing that changelog threw:

```
Error: Cannot find package 'prettier-plugin-svelte' imported from …/noop.js
    at … writeFormattedMarkdownFile … updateChangelog … applyReleasePlan … version
🦋  All files have been updated. Review them and commit at your leisure
```

changesets catches it, prints the stack, and **exits 0 claiming success**. So `delivery.yml` opened a Version Packages PR with the entry missing and the stack trace buried in the log.

Reproduced on `main` before changing anything — two plugin errors, exit 0, `apps/website/package.json` bumped with `apps/website/CHANGELOG.md` untouched. Exactly the two packages declaring the plugin were affected:

| package | bumped | changelog written |
| --- | --- | --- |
| `apps/website` | yes | **no** ← pre-existing |
| `examples/pg-sveltekit` | yes | **no** ← added by #145 |
| `apps/outlook-addon`, `apps/tb-addon`, `packages/pg-js`, `examples/pg-node` | yes | yes |

## Fixed at the root cause, not routed around

`prettier` and `prettier-plugin-svelte` are now root devDependencies. dobby's suggestion — adding the examples to changesets' `ignore` — closes the `examples/` half but leaves the website losing changelog entries, and the website is the real loss. After the fix: zero plugin errors and `apps/website/CHANGELOG.md` gains its `## 1.8.2` entry.

## A guard, because this class is invisible in normal use

`scripts/check-prettier-plugins.mjs` asserts every prettier plugin declared by any workspace member resolves from the root. A missing root plugin is undetectable day to day — each package's own `pnpm lint` resolves it fine from its own `node_modules` — so it has to be asserted rather than observed. It also fails when it finds no plugins at all, rather than passing over an empty set.

Wired into `integration.yml`, and into `version-packages` **ahead of** `changeset version`: that is where the damage happens, and failing the release beats producing a broken Version Packages PR.

Mutation-tested — with the root plugin removed, the guard exits 1 naming the declaring files, and in that same state I confirmed `changeset version` still exits 0 while leaving the website's changelog untouched. So the guard catches precisely the failure that shipped.

## Separately: the examples leave the release graph

They are private and unpublished, their versions are meaningless, and `privatePackages.version: true` plus `updateInternalDependencies: "patch"` meant every SDK release bumped two of them and grew changelogs nothing reads. With them in `ignore`, a pg-js patch touches neither:

```
apps/website           version=1.8.2   changelog_touched=1
apps/outlook-addon     version=1.0.1   changelog_touched=1
examples/pg-node       version=0.0.1   changelog_touched=0
examples/pg-sveltekit  version=0.0.1   changelog_touched=0
```

Also normalised the escaped em dash in `examples/pg-node/package.json` — changesets re-serialises that file on every run and writes the literal character, so it showed up as a spurious diff in each Version Packages PR.

## Not fixed here

`changeset version` exiting 0 after a failed changelog write is a changesets behaviour, not something this repo can fix. The guard closes the one route into it that we control.

Refs #145.
