### PR TITLE
docs(examples): correct four claims the code does not support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,12 @@ env:
     POSTGUARD_WEBSITE_URL: ${{ vars.POSTGUARD_WEBSITE_URL || 'https://postguard.eu' }}
 
 jobs:
+    # The broad lane, deliberately. It runs the recursive typecheck, build and test
+    # rather than filtering to the SDK the way `api-surface`, `bun` and `deno` do,
+    # because whole-workspace coverage is its job: apps/website and both addons
+    # included, which is what the `env:` block above exists to supply. Narrowing it
+    # would remove that coverage rather than relocate it. examples/* is cheap here,
+    # and examples.yml covering them again is duplication rather than a gap.
     node:
         name: Node ${{ matrix.node }}
         runs-on: ubuntu-latest
@@ -129,17 +135,9 @@ jobs:
 
             # Only the SDK: this lane exercises pg-js on the Bun runtime and
             # reads nothing from apps/* or examples/*. Same reasoning as
-            # api-surface below — filtering keeps the job out of the class where
+            # api-surface above — filtering keeps the job out of the class where
             # another package's build preconditions become this workflow's, which
             # the examples import would otherwise extend to two more builds.
-            #
-            # The `node` lane above is the deliberate exception and still runs the
-            # recursive typecheck, build and test. It is the one lane whose job IS
-            # whole-workspace coverage — apps/website and both addons included,
-            # which is what the env: block at the top exists to supply — so
-            # narrowing it would remove the coverage rather than relocate it. The
-            # examples are cheap there and examples.yml covers them again on its
-            # own, which is duplication rather than a gap.
             - name: Build the SDK
               run: pnpm --filter @e4a/pg-js build
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,6 +132,14 @@ jobs:
             # api-surface below — filtering keeps the job out of the class where
             # another package's build preconditions become this workflow's, which
             # the examples import would otherwise extend to two more builds.
+            #
+            # The `node` lane above is the deliberate exception and still runs the
+            # recursive typecheck, build and test. It is the one lane whose job IS
+            # whole-workspace coverage — apps/website and both addons included,
+            # which is what the env: block at the top exists to supply — so
+            # narrowing it would remove the coverage rather than relocate it. The
+            # examples are cheap there and examples.yml covers them again on its
+            # own, which is duplication rather than a gap.
             - name: Build the SDK
               run: pnpm --filter @e4a/pg-js build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,10 @@ Org-wide lesson: any repo combining gitignored generated sources with build-time
 - `src/email/envelope.ts`: HTML template for the PostGuard encrypted email; sender pill styles in `buildAttributePills`.
 - CI split: `delivery.yml` (release on push to main), `integration.yml` (PR checks: typecheck + build + test + smoke across Node 22/24, Bun, Deno).
 
+## Examples (`examples/*`)
+- `examples/pg-dotnet` multi-targets `net8.0;net10.0`, so a bare `dotnet run` fails with "Your project targets multiple frameworks" — every documented invocation needs `-f net10.0`. Building needs the .NET 10 SDK: it ships only its own targeting pack and `dotnet restore` fetches the `net8.0` one (`microsoft.netcore.app.ref`) from NuGet, which a cold cache turns into a network dependency. `--locked-mode` cannot block that fetch, because a targeting pack is not a `PackageReference` and never lands in `packages.lock.json`. Checked on SDK `10.0.100-rc.2`.
+- `UploadOptions.notify` is object-only in the types but unvalidated at runtime (`packages/pg-js/tests/postguard.test.ts` pins the old validator's removal). TypeScript callers get `TS2559` on `{ notify: true }`; the plain-JS examples get a silent no-mail upload with the silent-upload notice suppressed, since `notify` is defined. Keep example READMEs explicit that the check is compile-time only.
+
 ## Package scripts
 - `prebuild` / `pretypecheck` / `pretest` / `pretest:watch`: run all three generators.
 - `build`: tsdown.

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,7 @@ Requires the .NET 10.0+ SDK and a PostGuard API key. The example uses the `E4A.P
 ```bash
 cd examples/pg-dotnet
 export PG_API_KEY="PG-your-key-here"
-dotnet run
+dotnet run -f net10.0
 ```
 
 See [pg-dotnet/README.md](pg-dotnet/README.md) for full setup instructions.

--- a/examples/pg-dotnet/README.md
+++ b/examples/pg-dotnet/README.md
@@ -11,7 +11,10 @@ Example .NET console app demonstrating how to use the [postguard-dotnet](https:/
 
 - .NET 10.0+ SDK. The project targets `net8.0;net10.0`, and an SDK cannot build a
   target framework newer than itself, so the .NET 8 SDK fails on the `net10.0` target.
-  The .NET 10 SDK builds both, since it ships the net8.0 reference assemblies.
+  The .NET 10 SDK builds both: it ships only its own targeting pack, and `dotnet
+  restore` acquires the net8.0 one from NuGet. `--locked-mode` does not block that,
+  because a targeting pack is not a `PackageReference` and so is absent from
+  `packages.lock.json`.
 - A PostGuard API key
 
 ## Run
@@ -20,14 +23,14 @@ Store your API key with [user-secrets](https://learn.microsoft.com/en-us/aspnet/
 
 ```bash
 dotnet user-secrets set "PG_API_KEY" "PG-your-key-here"
-dotnet run
+dotnet run -f net10.0
 ```
 
 Or pass it via environment variable:
 
 ```bash
 export PG_API_KEY="PG-your-key-here"
-dotnet run
+dotnet run -f net10.0
 ```
 
 Override the default URLs (via user-secrets or env vars) if needed:

--- a/examples/pg-dotnet/README.md
+++ b/examples/pg-dotnet/README.md
@@ -67,7 +67,8 @@ var pg = new PostGuard(new PostGuardConfig
 });
 
 // Encrypt returns a lazy Sealed builder. Note the name: `sealed` is a C#
-// keyword, so it cannot be an identifier — Program.cs uses sealed1/sealed2.
+// keyword, so it cannot be used bare as an identifier. `@sealed` compiles,
+// but reads worse than a name, which is why Program.cs uses sealed1/sealed2.
 var sealedFiles = pg.Encrypt(new EncryptInput
 {
     Files = [new PgFile("report.txt", stream)],

--- a/examples/pg-dotnet/README.md
+++ b/examples/pg-dotnet/README.md
@@ -9,7 +9,9 @@ Example .NET console app demonstrating how to use the [postguard-dotnet](https:/
 
 ## Prerequisites
 
-- .NET 8.0 or 10.0 SDK
+- .NET 10.0+ SDK. The project targets `net8.0;net10.0`, and an SDK cannot build a
+  target framework newer than itself, so the .NET 8 SDK fails on the `net10.0` target.
+  The .NET 10 SDK builds both, since it ships the net8.0 reference assemblies.
 - A PostGuard API key
 
 ## Run
@@ -61,8 +63,9 @@ var pg = new PostGuard(new PostGuardConfig
     CryptifyUrl = "https://storage.staging.postguard.eu"
 });
 
-// Encrypt returns a lazy Sealed builder
-var sealed = pg.Encrypt(new EncryptInput
+// Encrypt returns a lazy Sealed builder. Note the name: `sealed` is a C#
+// keyword, so it cannot be an identifier — Program.cs uses sealed1/sealed2.
+var sealedFiles = pg.Encrypt(new EncryptInput
 {
     Files = [new PgFile("report.txt", stream)],
     Recipients = [
@@ -73,10 +76,10 @@ var sealed = pg.Encrypt(new EncryptInput
 });
 
 // Silent upload (no Cryptify-sent emails). Returns UUID for custom distribution.
-var result = await sealed.UploadAsync();
+var silentResult = await sealedFiles.UploadAsync();
 
 // Or upload + have Cryptify email the recipients (and optionally the sender).
-var result = await sealed.UploadAsync(new UploadOptions
+var notifiedResult = await sealedFiles.UploadAsync(new UploadOptions
 {
     Notify = new NotifyOptions
     {

--- a/examples/pg-node/README.md
+++ b/examples/pg-node/README.md
@@ -74,4 +74,9 @@ const sealed = pg.encrypt({
 const { uuid } = await sealed.upload({ notify: { recipients: true, message, language: 'EN' } });
 ```
 
-`notify` must be nested under an object. The SDK validates the shape and throws a clear `TypeError` if you pass `{ notify: true }` or forget to nest. See the [SDK README](https://github.com/encryption4all/postguard-js#server-side-usage-node-bun-deno) for the full server-side surface.
+`notify` must be nested under an object, and **nothing checks that for you** — `{ notify: true }` fails silently and is worse than omitting `notify` altogether:
+
+- `delivery?.recipients` on `true` is `undefined`, so `false` goes on the wire and no mail is sent;
+- and because `notify` *is* defined, the SDK's silent-upload notice does not fire either, so there is no warning.
+
+There was once a runtime validator, but it hand-maintained an allowlist of upload keys and rejected valid options when the types moved ahead of it; `packages/pg-js/tests/postguard.test.ts` pins its removal. Passing `{ notify: { recipients: false } }` when you mean silence is the way to be explicit. See the [SDK README](https://github.com/encryption4all/postguard-js#server-side-usage-node-bun-deno) for the full server-side surface.

--- a/examples/pg-node/README.md
+++ b/examples/pg-node/README.md
@@ -74,7 +74,7 @@ const sealed = pg.encrypt({
 const { uuid } = await sealed.upload({ notify: { recipients: true, message, language: 'EN' } });
 ```
 
-`notify` must be nested under an object, and **nothing checks that for you** — `{ notify: true }` fails silently and is worse than omitting `notify` altogether:
+`notify` must be nested under an object, and **nothing checks that at runtime** — `{ notify: true }` fails silently and is worse than omitting `notify` altogether:
 
 - reading `.recipients` off the boolean `true` yields `undefined`, so `false` goes on the wire and no mail is sent;
 - and because `notify` *is* defined, the SDK's silent-upload notice does not fire either, so there is no warning.

--- a/examples/pg-node/README.md
+++ b/examples/pg-node/README.md
@@ -76,7 +76,7 @@ const { uuid } = await sealed.upload({ notify: { recipients: true, message, lang
 
 `notify` must be nested under an object, and **nothing checks that for you** — `{ notify: true }` fails silently and is worse than omitting `notify` altogether:
 
-- `delivery?.recipients` on `true` is `undefined`, so `false` goes on the wire and no mail is sent;
+- reading `.recipients` off the boolean `true` yields `undefined`, so `false` goes on the wire and no mail is sent;
 - and because `notify` *is* defined, the SDK's silent-upload notice does not fire either, so there is no warning.
 
 There was once a runtime validator, but it hand-maintained an allowlist of upload keys and rejected valid options when the types moved ahead of it; `packages/pg-js/tests/postguard.test.ts` pins its removal. Passing `{ notify: { recipients: false } }` when you mean silence is the way to be explicit. See the [SDK README](https://github.com/encryption4all/postguard-js#server-side-usage-node-bun-deno) for the full server-side surface.

--- a/examples/pg-sveltekit/src/lib/config.ts
+++ b/examples/pg-sveltekit/src/lib/config.ts
@@ -24,6 +24,3 @@ export const IS_CRYPTIFY_STAGING = detectStagingCryptify(CRYPTIFY_URL);
 export const DOWNLOAD_URL =
 	env.PUBLIC_DOWNLOAD_URL ||
 	(IS_CRYPTIFY_STAGING ? 'https://staging.postguard.eu' : 'https://postguard.eu');
-
-export const UPLOAD_CHUNK_SIZE = 1024 * 1024; // 1MB
-export const FILEREAD_CHUNK_SIZE = 1024 * 1024; // 1MB


### PR DESCRIPTION
Four claims in `examples/` that the code does not support, from dobby's review of #145. All four were imported verbatim from the archived `postguard-examples`, and each is the class the import exists to close: an example teaching something untrue.

## `pg-node`'s README promised a guardrail that was deliberately removed

> The SDK validates the shape and throws a clear `TypeError` if you pass `{ notify: true }` or forget to nest.

No such validator exists. `packages/pg-js/tests/postguard.test.ts` pins its *removal* — it hand-maintained an allowlist of upload keys and rejected valid options when the types moved ahead of it.

Worse, the footgun it claimed to guard is silent, and strictly worse than omitting the option. Traced through the production path rather than assumed:

| step | result |
| --- | --- |
| `delivery?.recipients` where `delivery` is `true` (`crypto/encrypt.ts:104`) | `undefined` |
| `options.notifyRecipients ?? false` (`api/cryptify.ts:112`) | `false` on the wire — no mail |
| `opts?.notify === undefined` (`sealed.ts:98`) | `false`, so the silent-upload notice **does not fire** |

So `{ notify: true }` sends no mail *and* suppresses the warning that would have said so. The README now says exactly that, and points at `{ notify: { recipients: false } }` as the way to mean silence.

## `pg-dotnet`'s README claimed an SDK that cannot build it

`.NET 8.0 or 10.0 SDK` is not achievable: the project targets `net8.0;net10.0`, and an SDK cannot build a target framework newer than itself, so the .NET 8 SDK fails on `net10.0`. `examples/README.md` already said "10.0+", so the two READMEs this repo ships contradicted each other. `examples.yml` installing both is about runtimes, not about what can drive the build.

## `pg-dotnet`'s README snippet could not compile

`sealed` is a C# keyword, so `var sealed = pg.Encrypt(…)` is `CS1585`/`CS1525` — and `var result` was then declared twice in one scope (`CS0128`). `Program.cs` uses `sealed1`/`sealed2` and `result1`/`result2` for precisely this reason. The snippet now uses named variables and says why, since this is the file the .NET surface is taught from.

## `pg-sveltekit` exported two constants nothing reads

`UPLOAD_CHUNK_SIZE = 1MB` read as "this example uploads in 1 MB chunks", but `new PostGuard({ pkgUrl, cryptifyUrl })` never passes `uploadChunkSize`, so the SDK's `DEFAULT_UPLOAD_CHUNK_SIZE` of 5,000,000 is what actually runs. `FILEREAD_CHUNK_SIZE` is unread too.

Deleted rather than wired in: the example demonstrates nothing else about chunk tuning, and configuration that is not applied is the class this workspace has been removing (`.npmrc`, both `overrides` blocks, `.prettierignore`). Wiring it would be a deliberate change about what the example teaches, and should be argued as one.

## Also

Recorded why `integration.yml`'s `node` lane is the deliberate exception to the `--filter` reasoning the `bun`, `deno` and `api-surface` lanes carry. It is the one lane whose job *is* whole-workspace coverage — both addons included, which is what its `env:` block exists to supply (`apps/website` is covered by the lane too, but reads its own committed `.env`, so it needs nothing from that block) — so narrowing it would remove coverage rather than relocate it. The examples are cheap there, and `examples.yml` covering them again is duplication rather than a gap.

Verified: `pg-sveltekit` typecheck, build and lint clean; `pg-node` typecheck clean; `pg-dotnet` builds `net8.0` + `net10.0`; `actionlint` clean.

The wording fix on that `integration.yml` comment cannot ship in this branch — the bot has no `workflows` permission, so the push is rejected. It is a one-line patch in a comment below for a maintainer to apply.

Refs #145.

