### PR TITLE
fix(pg-sveltekit): give the example's controls accessible names and state

### DIFF
--- a/examples/pg-sveltekit/src/lib/components/ProgressBar.svelte
+++ b/examples/pg-sveltekit/src/lib/components/ProgressBar.svelte
@@ -7,11 +7,29 @@
 	let { percentage, label = '' }: Props = $props();
 </script>
 
-<div class="progress-container">
+<!--
+	The track carries role="progressbar" and its value, so assistive tech reports
+	progress rather than seeing three unlabelled divs. aria-valuetext gives the
+	rounded percentage the visible text shows, instead of a long float.
+
+	aria-live="polite" on the container announces changes; without it the value
+	updates silently. It sits on the container rather than the track so the label
+	is part of the announcement.
+-->
+<div class="progress-container" aria-live="polite">
 	{#if label}
-		<div class="progress-label">{label}</div>
+		<div class="progress-label" id="progress-label">{label}</div>
 	{/if}
-	<div class="progress-track">
+	<div
+		class="progress-track"
+		role="progressbar"
+		aria-valuenow={Math.round(percentage)}
+		aria-valuemin="0"
+		aria-valuemax="100"
+		aria-valuetext="{Math.round(percentage)}%"
+		aria-label={label ? undefined : 'Progress'}
+		aria-labelledby={label ? 'progress-label' : undefined}
+	>
 		<div class="progress-fill" style="width: {Math.min(100, percentage)}%"></div>
 	</div>
 	<div class="progress-text">{Math.round(percentage)}%</div>

--- a/examples/pg-sveltekit/src/lib/components/ProgressBar.svelte
+++ b/examples/pg-sveltekit/src/lib/components/ProgressBar.svelte
@@ -5,6 +5,18 @@
 	}
 
 	let { percentage, label = '' }: Props = $props();
+
+	// Per-instance, not a literal: a hardcoded id in a reusable component makes a
+	// second <ProgressBar> on the same page resolve its accessible name to the
+	// FIRST one's label, and duplicate ids are invalid HTML besides. Only one
+	// instance exists today, but a wrong accessible name is the failure this
+	// component was just fixed to avoid.
+	const labelId = $props.id();
+
+	// aria-valuenow has to sit inside min/max per ARIA, and the fill was already
+	// clamped for the same reason — the prop is arbitrary even though the app's
+	// own onProgress clamps before calling. One value feeds all three.
+	const shown = $derived(Math.max(0, Math.min(100, Math.round(percentage))));
 </script>
 
 <!--
@@ -13,26 +25,31 @@
 	rounded percentage the visible text shows, instead of a long float.
 
 	aria-live="polite" on the container announces changes; without it the value
-	updates silently. It sits on the container rather than the track so the label
-	is part of the announcement.
+	updates silently. aria-atomic is left at its default of false, so what is
+	announced is the changed node alone — a bare "42%" — rather than the label and
+	percentage together. That is deliberate: the SDK uploads in 5 MB chunks, so a
+	100 MB upload fires around 20 progress events, and re-announcing
+	"Encrypting & uploading… 42%" each time is worse than the percentage alone.
+	The label is still the track's accessible name via aria-labelledby, so it is
+	there on focus.
 -->
 <div class="progress-container" aria-live="polite">
 	{#if label}
-		<div class="progress-label" id="progress-label">{label}</div>
+		<div class="progress-label" id={labelId}>{label}</div>
 	{/if}
 	<div
 		class="progress-track"
 		role="progressbar"
-		aria-valuenow={Math.round(percentage)}
+		aria-valuenow={shown}
 		aria-valuemin="0"
 		aria-valuemax="100"
-		aria-valuetext="{Math.round(percentage)}%"
+		aria-valuetext="{shown}%"
 		aria-label={label ? undefined : 'Progress'}
-		aria-labelledby={label ? 'progress-label' : undefined}
+		aria-labelledby={label ? labelId : undefined}
 	>
-		<div class="progress-fill" style="width: {Math.min(100, percentage)}%"></div>
+		<div class="progress-fill" style="width: {shown}%"></div>
 	</div>
-	<div class="progress-text">{Math.round(percentage)}%</div>
+	<div class="progress-text">{shown}%</div>
 </div>
 
 <style>

--- a/examples/pg-sveltekit/src/routes/+page.svelte
+++ b/examples/pg-sveltekit/src/routes/+page.svelte
@@ -172,16 +172,20 @@
 	<section>
 		<div class="mode-toggle">
 			<button
+				type="button"
 				class="mode-btn"
 				class:active={deliveryMode === 'send-email'}
+				aria-pressed={deliveryMode === 'send-email'}
 				onclick={() => (deliveryMode = 'send-email')}
 			>
 				<span class="mode-title">Send email</span>
 				<span class="mode-desc">Cryptify emails recipients a download link</span>
 			</button>
 			<button
+				type="button"
 				class="mode-btn"
 				class:active={deliveryMode === 'upload-only'}
+				aria-pressed={deliveryMode === 'upload-only'}
 				onclick={() => (deliveryMode = 'upload-only')}
 			>
 				<span class="mode-title">Upload only</span>
@@ -199,8 +203,14 @@
 		<h2>2. Citizen recipient</h2>
 		<p class="hint">Must prove their exact email address to decrypt.</p>
 		<div class="field-group">
-			<input type="text" bind:value={citizenName} placeholder="Name" />
-			<input type="email" bind:value={citizenEmail} placeholder="citizen@example.com" />
+			<label class="field">
+				<span class="field-label">Name</span>
+				<input type="text" bind:value={citizenName} />
+			</label>
+			<label class="field">
+				<span class="field-label">Email address</span>
+				<input type="email" bind:value={citizenEmail} placeholder="citizen@example.com" />
+			</label>
 		</div>
 	</section>
 
@@ -213,32 +223,43 @@
 			{/if}.
 		</p>
 		<div class="field-group">
-			<input type="text" bind:value={orgName} placeholder="Organisation name" />
-			<input type="email" bind:value={orgEmail} placeholder="info@organisation.nl" />
+			<label class="field">
+				<span class="field-label">Organisation name</span>
+				<input type="text" bind:value={orgName} />
+			</label>
+			<label class="field">
+				<span class="field-label">Email address at the organisation</span>
+				<input type="email" bind:value={orgEmail} placeholder="info@organisation.nl" />
+			</label>
 		</div>
 	</section>
 
 	<section>
 		<h2>4. API key</h2>
 		<p class="hint">PostGuard API key for sender authentication.</p>
-		<input
-			type="password"
-			bind:value={apiKey}
-			placeholder="PG-1a2b3c4d5e6f7g8h"
-			autocomplete="off"
-		/>
+		<label class="field">
+			<span class="field-label">API key</span>
+			<input
+				type="password"
+				bind:value={apiKey}
+				placeholder="PG-1a2b3c4d5e6f7g8h"
+				autocomplete="off"
+			/>
+		</label>
 	</section>
 
 	{#if deliveryMode === 'send-email'}
 		<section>
 			<h2>5. Message (optional)</h2>
-			<textarea bind:value={message} placeholder="Add a message for the recipients..." rows="3"
-			></textarea>
+			<label class="field">
+				<span class="field-label">Message for the recipients</span>
+				<textarea bind:value={message} rows="3"></textarea>
+			</label>
 		</section>
 	{/if}
 
 	{#if sendState === 'error'}
-		<div class="error-box">
+		<div class="error-box" role="alert">
 			<p>Error: {errorMessage}</p>
 		</div>
 	{/if}
@@ -317,13 +338,24 @@
 	}
 
 	/* Form fields */
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		flex: 1;
+	}
+	.field-label {
+		font-size: 0.85rem;
+		color: #444;
+	}
 	.field-group {
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
 	}
-	.field-group input,
-	section > input {
+	/* `section > input` before the labels went in; every input now sits inside a
+	   .field label, including the API key one that used to be a direct child. */
+	.field input {
 		padding: 0.5rem;
 		border: 1px solid #ccc;
 		border-radius: 4px;

--- a/examples/pg-sveltekit/src/routes/+page.svelte
+++ b/examples/pg-sveltekit/src/routes/+page.svelte
@@ -165,7 +165,7 @@
 				<code class="download-url">{DOWNLOAD_URL}/download?uuid={resultUuid}</code>
 			</div>
 		{/if}
-		<button class="primary-btn" onclick={handleReset}>Start over</button>
+		<button type="button" class="primary-btn" onclick={handleReset}>Start over</button>
 	</div>
 {:else}
 	<!-- Delivery mode toggle -->
@@ -204,11 +204,11 @@
 		<p class="hint">Must prove their exact email address to decrypt.</p>
 		<div class="field-group">
 			<label class="field">
-				<span class="field-label">Name</span>
+				<span class="field-label">Citizen name</span>
 				<input type="text" bind:value={citizenName} />
 			</label>
 			<label class="field">
-				<span class="field-label">Email address</span>
+				<span class="field-label">Citizen email address</span>
 				<input type="email" bind:value={citizenEmail} placeholder="citizen@example.com" />
 			</label>
 		</div>
@@ -267,10 +267,10 @@
 	{#if sendState === 'encrypting'}
 		<section>
 			<ProgressBar percentage={progress} label="Encrypting & uploading..." />
-			<button class="cancel-btn" onclick={handleCancel}>Cancel</button>
+			<button type="button" class="cancel-btn" onclick={handleCancel}>Cancel</button>
 		</section>
 	{:else}
-		<button class="primary-btn" disabled={!canSend} onclick={handleSubmit}>
+		<button type="button" class="primary-btn" disabled={!canSend} onclick={handleSubmit}>
 			{deliveryMode === 'send-email' ? 'Encrypt & Send' : 'Encrypt & Upload'}
 		</button>
 	{/if}
@@ -338,11 +338,13 @@
 	}
 
 	/* Form fields */
+	/* No `flex: 1`: .field-group is column-direction, so it equalised height rather
+	   than putting fields side by side — dead space once a label wrapped — and at the
+	   two section-level usages .field is not a flex item at all. */
 	.field {
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
-		flex: 1;
 	}
 	.field-label {
 		font-size: 0.85rem;


### PR DESCRIPTION
From dobby's review of #145. `+page.svelte` is byte-identical to the archived `postguard-examples`, so this is **relocated debt rather than something the import introduced** — but it is the app docs.postguard.eu teaches from, in a repo whose stated bar is WCAG 2.2 AA, and it would otherwise stay buried in a 4000-line import.

## Six placeholder-only controls

The citizen name and email, the organisation name and email, the API key, and the message textarea had no label at all. A placeholder is not one: the accessible name disappears the moment the user types, and there is no programmatic field/label association. That fails **1.3.1**, **3.3.2** and **4.1.2**.

Each control is now wrapped in a `<label>` with visible text. Placeholders that carried a sample value (`citizen@example.com`, `PG-1a2b3c4d5e6f7g8h`) keep it as a format hint rather than as the name.

## The delivery-mode toggle had no exposed state

Selection lived only in `class:active`, so a screen-reader user could not tell which mode was active. Both buttons now expose `aria-pressed`, per the ARIA APG toggle-pair pattern, and both got the explicit `type="button"` they were missing.

## ProgressBar was three bare divs

No role, no value, no accessible name (**4.1.2**), and no announcement as it advanced (**4.1.3**). The track now carries `role="progressbar"` with `aria-valuenow/min/max`, plus `aria-valuetext` matching the rounded percentage the visible text shows rather than a long float.

Its name comes from the existing label via `aria-labelledby`, falling back to `aria-label` when no label is passed — so the name is never absent either way. `aria-live="polite"` sits on the container rather than the track, so the label is part of the announcement instead of a bare number.

## The error box was silent

No `role="alert"`, so a failed send was invisible to assistive technology. It has one now.

## One CSS consequence, fixed rather than left latent

`section > input` matched the API key field as a direct child; wrapping it in a label made that selector dead, which `svelte-check` flagged. Replaced with `.field input`, which covers every input now that they all sit inside one. Back to **0 errors / 0 warnings**.

## Verified at the built output

Not just the source — `role="progressbar"`, `aria-valuenow`, `aria-pressed`, `aria-live` and `role="alert"` all appear in `.svelte-kit/output`, and the new label text renders. Build and lint clean.

## Not covered here

`FileDropzone.svelte` has no aria attributes at all. A drop target's keyboard and screen-reader story is a design question rather than an attribute fix, so it wants its own change rather than being guessed at in this one.

Refs #145.
