### PR TITLE
ci: qualify both nginx config check names with their app

### DIFF
--- a/.github/workflows/outlook-addon.yml
+++ b/.github/workflows/outlook-addon.yml
@@ -231,7 +231,13 @@ jobs:
                   exit "$fail"
 
     nginx:
-        name: nginx config test
+        # Qualified with the app, and it has to stay that way: website.yml has a
+        # job that validates ITS nginx config, and a required status check is
+        # matched by name across the whole repo. While both were called
+        # `nginx config test`, requiring that name covered both copies — and
+        # deleting either job would have left the name still reporting from the
+        # other, so the gate would look alive while covering half of it.
+        name: nginx config test (outlook-addon)
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -107,7 +107,11 @@ jobs:
             - run: pnpm lint:css
 
     nginx:
-        name: nginx config test
+        # Qualified with the app — see the matching note in outlook-addon.yml.
+        # Both jobs were called `nginx config test`, and a required status check
+        # is matched by name across the whole repo, so the two were
+        # indistinguishable to branch protection.
+        name: nginx config test (website)
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to #155. `apps/outlook-addon` and `apps/website` each have a job named `nginx config test`, and a required status check is matched by name across the whole repository — so branch protection could not tell them apart. Both were left out of the required set in #155 for that reason; this makes them requireable.

- `nginx config test` → `nginx config test (outlook-addon)` — runs `nginx -t` against `apps/outlook-addon/nginx/default.conf` inside `nginx:1.27-alpine`
- `nginx config test` → `nginx config test (website)` — parses `docker/nginx.dev.conf` and `docker/default.conf.template` with crossplane

Only the display `name:` changes. Both job ids stay `nginx`, so `outlook-addon.yml`'s `needs: [check, test, urls, nginx]` is untouched.

The sharp edge, recorded in a comment on both jobs so neither gets "simplified" back: with a shared name, requiring it covers both copies, and deleting either job leaves the name still reporting from the other. The check would look alive while covering half of what you assume.

Both names go into the ruleset once this merges, bringing the required set to 20.

`actionlint` clean on both files — the three shellcheck findings it reports in `website.yml` are pre-existing and identical on unmodified `main`.

Part of encryption4all/postguard#247.