### PR TITLE
feat(pg-js): one MIME reader, shared by both add-ins

### DIFF
--- a/.changeset/shared-mime-reader.md
+++ b/.changeset/shared-mime-reader.md
@@ -1,0 +1,12 @@
+---
+'@e4a/pg-js': minor
+---
+
+Export the MIME reader, PostGuard detection and the archival armor readers, so both add-ins read the envelope through one implementation instead of two hand-rolled copies.
+
+New exports: `parseDecryptedMime`, `readMimeHeader`, `bodyFromMime`, `isMultipart`, `detectPostGuard`, `extractArmoredCiphertext`, `looksLikeArmoredPostGuard`, `POSTGUARD_ENCRYPTED_FILENAME`, and the `ParsedMessage` / `ParsedAttachment` / `DetectPostGuardInput` types. Additive only — no existing signature changes.
+
+Two fixes came out of the move:
+
+- **Quoted-printable bodies with non-ASCII characters were decoded wrong.** Each `=XX` was mapped through `String.fromCharCode`, giving one character per octet, so `caf=C3=A9` read back as `cafÃ©` rather than `café`. The byte path compounded it by re-encoding that as UTF-8, doubling every octet above 0x7f and silently corrupting quoted-printable attachments. Octets are now collected and decoded once.
+- `extractCiphertext`'s documentation claimed it read "attachment or armored body". It has only ever read the attachment. The armor path is now a separate, explicitly archival export, which is what `COMPATIBILITY.md`'s never-drops guarantee for stored artifacts actually requires.

--- a/apps/outlook-addon/src/launchevent/launchevent.ts
+++ b/apps/outlook-addon/src/launchevent/launchevent.ts
@@ -36,7 +36,8 @@ import {
   setItemHeaders,
   setSubject,
 } from "../lib/office-helpers";
-import { guessContentType, POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
+import { guessContentType } from "../lib/mime";
+import { POSTGUARD_ENCRYPTED_FILENAME } from "@e4a/pg-js";
 import {
   ENCRYPTION_STATUS_NOTIFICATION_KEY,
   HEADER_ENCRYPT_ON_SEND,

--- a/apps/outlook-addon/src/lib/mime.ts
+++ b/apps/outlook-addon/src/lib/mime.ts
@@ -1,211 +1,27 @@
-// Minimal MIME helpers to detect PostGuard ciphertext and pull headers
-// out of decrypted plaintext MIME.
+// Office.js-specific MIME glue.
 //
-// We deliberately do NOT try to be a full RFC 5322 parser — only the
-// pieces PostGuard needs: thread-related headers and the ASCII-armored
-// ciphertext block.
+// The MIME parsing, header reading, PostGuard detection and archival armor
+// readers that used to live here now come from `@e4a/pg-js`, so Thunderbird
+// and Outlook read the same shape by construction rather than by two hand-
+// rolled parsers agreeing (encryption4all/postguard-js#129). Import them from
+// the SDK directly:
+//
+//   import {
+//     POSTGUARD_ENCRYPTED_FILENAME, detectPostGuard, parseDecryptedMime,
+//     readMimeHeader, extractArmoredCiphertext, looksLikeArmoredPostGuard,
+//   } from "@e4a/pg-js";
+//
+// What is left is genuinely host-specific: it exists because of a limitation
+// in Office.js, not because of anything about PostGuard.
 
-const ARMOR_BEGIN = "-----BEGIN POSTGUARD MESSAGE-----";
-const ARMOR_END = "-----END POSTGUARD MESSAGE-----";
-
-export function extractArmoredCiphertext(htmlOrText: string): string | null {
-  if (!htmlOrText) return null;
-  const begin = htmlOrText.indexOf(ARMOR_BEGIN);
-  if (begin < 0) return null;
-  const end = htmlOrText.indexOf(ARMOR_END, begin);
-  if (end < 0) return null;
-  const block = htmlOrText.slice(begin + ARMOR_BEGIN.length, end);
-  // Strip whitespace and any HTML tags that may have been wrapped around it.
-  return block.replace(/<[^>]+>/g, "").replace(/\s+/g, "");
-}
-
-export function looksLikePostGuard(htmlOrText: string): boolean {
-  if (!htmlOrText) return false;
-  return htmlOrText.indexOf(ARMOR_BEGIN) >= 0;
-}
-
-// Pull a single header value (case-insensitive) out of a raw MIME blob.
-export function readMimeHeader(rawMime: string, name: string): string | undefined {
-  if (!rawMime) return undefined;
-  const lcName = name.toLowerCase();
-  // Header section ends at the first blank line (CRLF or LF).
-  const headerEnd = rawMime.search(/\r?\n\r?\n/);
-  const headerSection = headerEnd >= 0 ? rawMime.slice(0, headerEnd) : rawMime;
-  // Unfold continuations.
-  const unfolded = headerSection.replace(/\r?\n[ \t]+/g, " ");
-  for (const line of unfolded.split(/\r?\n/)) {
-    const idx = line.indexOf(":");
-    if (idx < 0) continue;
-    if (line.slice(0, idx).trim().toLowerCase() === lcName) {
-      return line.slice(idx + 1).trim();
-    }
-  }
-  return undefined;
-}
-
-// Strip MIME headers, return a best-effort body. If multipart we just
-// return the original — the SDK normally yields a single text/html part.
-export function bodyFromMime(rawMime: string): string {
-  const headerEnd = rawMime.search(/\r?\n\r?\n/);
-  return headerEnd >= 0 ? rawMime.slice(headerEnd).replace(/^\r?\n\r?\n/, "") : rawMime;
-}
-
-// Returns true if the message looks like a multipart/* body.
-export function isMultipart(rawMime: string): boolean {
-  const ct = readMimeHeader(rawMime, "Content-Type") ?? "";
-  return /^multipart\//i.test(ct);
-}
-
-export interface ParsedMessage {
-  htmlBody: string | null;
-  plainBody: string | null;
-  attachments: ParsedAttachment[];
-}
-
-export interface ParsedAttachment {
-  name: string;
-  type: string;
-  data: Uint8Array;
-}
-
-// Pulls the user-facing body and any attachments out of a decrypted MIME
-// blob. Handles a single text part or a multipart/* envelope. Decodes
-// base64 and quoted-printable transfer encodings; other encodings (7bit,
-// 8bit, binary) are passed through as-is.
-export function parseDecryptedMime(rawMime: string): ParsedMessage {
-  const result: ParsedMessage = { htmlBody: null, plainBody: null, attachments: [] };
-  collectParts(rawMime, result);
-  return result;
-}
-
-interface RawPart {
-  headers: Record<string, string>;
-  body: string;
-}
-
-function splitHeadersAndBody(raw: string): RawPart {
-  const headerEnd = raw.search(/\r?\n\r?\n/);
-  if (headerEnd < 0) return { headers: {}, body: raw };
-  const headerSection = raw.slice(0, headerEnd);
-  const body = raw.slice(headerEnd).replace(/^\r?\n\r?\n/, "");
-  const unfolded = headerSection.replace(/\r?\n[ \t]+/g, " ");
-  const headers: Record<string, string> = {};
-  for (const line of unfolded.split(/\r?\n/)) {
-    const idx = line.indexOf(":");
-    if (idx < 0) continue;
-    const name = line.slice(0, idx).trim().toLowerCase();
-    headers[name] = line.slice(idx + 1).trim();
-  }
-  return { headers, body };
-}
-
-function collectParts(raw: string, out: ParsedMessage): void {
-  const part = splitHeadersAndBody(raw);
-  const ct = part.headers["content-type"] ?? "text/plain";
-  const ctMain = ct.split(";")[0].trim().toLowerCase();
-
-  if (ctMain.startsWith("multipart/")) {
-    const boundary = paramFromHeader(ct, "boundary");
-    if (!boundary) return;
-    for (const child of splitByBoundary(part.body, boundary)) {
-      collectParts(child, out);
-    }
-    return;
-  }
-
-  const cd = part.headers["content-disposition"] ?? "";
-  const cte = (part.headers["content-transfer-encoding"] ?? "7bit").toLowerCase();
-  const filename = paramFromHeader(cd, "filename") ?? paramFromHeader(ct, "name");
-  const isAttachment = /attachment/i.test(cd) || (filename != null && !ctMain.startsWith("text/"));
-
-  if (isAttachment) {
-    out.attachments.push({
-      name: filename ?? "attachment",
-      type: ctMain,
-      data: decodeToBytes(part.body, cte),
-    });
-    return;
-  }
-
-  const text = decodeToString(part.body, cte);
-  if (ctMain === "text/html" && out.htmlBody == null) {
-    out.htmlBody = text;
-  } else if (ctMain === "text/plain" && out.plainBody == null) {
-    out.plainBody = text;
-  } else if (out.htmlBody == null && out.plainBody == null) {
-    // Unknown text-ish content; treat as plain.
-    out.plainBody = text;
-  }
-}
-
-function paramFromHeader(value: string, name: string): string | null {
-  const re = new RegExp(`(?:^|;)\\s*${name}\\s*=\\s*"?([^";]+)"?`, "i");
-  const m = value.match(re);
-  return m ? m[1].trim() : null;
-}
-
-function splitByBoundary(body: string, boundary: string): string[] {
-  const escaped = boundary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Boundaries appear on their own line: --boundary, with --boundary--
-  // marking the close. We split on either form, then drop the preamble
-  // (before the first boundary) and epilogue (after the close).
-  const re = new RegExp(`(?:^|\\r?\\n)--${escaped}(?:--)?[^\\n]*\\r?\\n?`, "g");
-  const pieces = body.split(re);
-  // First element is the preamble (before first boundary), discard.
-  // The last may be the epilogue or the after-close section, also drop empties.
-  const parts = pieces.slice(1).filter((p) => p.length > 0);
-  return parts;
-}
-
-function decodeToBytes(body: string, encoding: string): Uint8Array {
-  if (encoding === "base64") {
-    const cleaned = body.replace(/\s/g, "");
-    try {
-      const bin = atob(cleaned);
-      const bytes = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-      return bytes;
-    } catch {
-      return new Uint8Array();
-    }
-  }
-  if (encoding === "quoted-printable") {
-    return new TextEncoder().encode(decodeQuotedPrintable(body));
-  }
-  return new TextEncoder().encode(body);
-}
-
-function decodeToString(body: string, encoding: string): string {
-  if (encoding === "base64") {
-    const cleaned = body.replace(/\s/g, "");
-    try {
-      const bin = atob(cleaned);
-      const bytes = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-      return new TextDecoder("utf-8").decode(bytes);
-    } catch {
-      return body;
-    }
-  }
-  if (encoding === "quoted-printable") {
-    return decodeQuotedPrintable(body);
-  }
-  return body;
-}
-
-function decodeQuotedPrintable(s: string): string {
-  return s
-    .replace(/=\r?\n/g, "")
-    .replace(/=([0-9A-F]{2})/gi, (_m, hex) => String.fromCharCode(parseInt(hex, 16)));
-}
-
-export const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
-
-// Best-effort MIME type from a filename extension. Used when reading an
-// Office.js attachment, which only hands us a name (no Content-Type).
-// The map is intentionally short — anything not listed falls back to
-// application/octet-stream, which both pg-js and recipient mail clients
-// handle correctly.
+// Best-effort MIME type from a filename extension.
+//
+// Office.js hands back an attachment name and no Content-Type, so the type has
+// to be reconstructed before the bytes can go into a MIME part. The map is
+// deliberately short: anything unlisted falls back to application/octet-stream,
+// which both pg-js and recipient mail clients handle correctly. This does not
+// belong in the SDK — no other host needs it, because no other host has the
+// gap it works around.
 export function guessContentType(name: string): string {
   const ext = name.toLowerCase().split(".").pop() ?? "";
   const map: Record<string, string> = {

--- a/apps/outlook-addon/src/taskpane/compose-view.ts
+++ b/apps/outlook-addon/src/taskpane/compose-view.ts
@@ -31,7 +31,8 @@ import {
   clientHeaders,
 } from "../lib/pkg-client";
 import { byId } from "../lib/dom";
-import { guessContentType, POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
+import { guessContentType } from "../lib/mime";
+import { POSTGUARD_ENCRYPTED_FILENAME } from "@e4a/pg-js";
 import {
   ENCRYPTION_STATUS_NOTIFICATION_KEY,
   HEADER_ENCRYPT_ON_SEND,

--- a/apps/outlook-addon/src/taskpane/read-view.ts
+++ b/apps/outlook-addon/src/taskpane/read-view.ts
@@ -5,7 +5,15 @@
 // decrypted content is shown only inside this taskpane and a small
 // notification banner is added to the message.
 
-import { PostGuard } from "@e4a/pg-js";
+import {
+  PostGuard,
+  POSTGUARD_ENCRYPTED_FILENAME,
+  extractArmoredCiphertext,
+  looksLikeArmoredPostGuard,
+  parseDecryptedMime,
+  readMimeHeader,
+  type ParsedAttachment,
+} from "@e4a/pg-js";
 import {
   getReadAttachments,
   readReadAttachmentBytes,
@@ -17,14 +25,6 @@ import {
   showNotification,
 } from "../lib/office-helpers";
 import { fromBase64, toBase64, bytesToUtf8 } from "../lib/encoding";
-import {
-  POSTGUARD_ENCRYPTED_FILENAME,
-  extractArmoredCiphertext,
-  looksLikePostGuard,
-  parseDecryptedMime,
-  ParsedAttachment,
-  readMimeHeader,
-} from "../lib/mime";
 import { Badge, FriendlySender } from "../lib/types";
 import {
   PKG_URL,
@@ -139,7 +139,7 @@ async function tryFindCiphertext(): Promise<Uint8Array | null> {
     if (armored) {
       return fromBase64(armored);
     }
-    if (looksLikePostGuard(html)) {
+    if (looksLikeArmoredPostGuard(html)) {
       // Armor markers were present but content not extractable — still
       // treat as encrypted so the user gets an error instead of silence.
       return new Uint8Array();

--- a/apps/tb-addon/src/lib/detection.ts
+++ b/apps/tb-addon/src/lib/detection.ts
@@ -1,33 +1,39 @@
 /// <reference path="../types/thunderbird.d.ts" />
 
-import { extractUploadUuid } from "@e4a/pg-js";
+import { detectPostGuard } from "@e4a/pg-js";
 import { findHtmlBody } from "./utils";
 
 /**
  * Detect whether a message looks like a current PostGuard ciphertext that
  * the user can still decrypt.
  *
- * Tier 1/2 envelopes ship a `postguard.encrypted` attachment. Tier 3 has no
- * attachment — the encrypted payload lives in Cryptify, with a
- * `/decrypt?uuid=…` link in the body. Both shapes are handled by the popup's
- * decrypt path; this function only answers "looks like PostGuard" so the
- * banner can offer the Decrypt button instead of falling back to the
- * wasEncrypted info banner.
+ * What counts as PostGuard is `detectPostGuard` in the SDK, not this file:
+ * the tiers do not look alike (tier 3 ships no attachment at all), and while
+ * each add-in carried its own copy of that rule they were free to disagree
+ * about it — which is the drift encryption4all/postguard-js#129 exists to
+ * remove. Everything left here is Thunderbird's WebExtension API, which the
+ * SDK cannot and should not reach.
+ *
+ * This function only answers "looks like PostGuard" so the banner can offer
+ * the Decrypt button instead of falling back to the wasEncrypted info banner.
  */
 export async function isPGEncrypted(msgId: number): Promise<boolean> {
+  // Attachments first, and the body only if they settle nothing: `getFull`
+  // pulls the whole message, and a tier-1/2 envelope is already decided by the
+  // cheap call. Folding both into one detectPostGuard call would fetch the body
+  // every time, and would turn a getFull failure on a message that DOES carry
+  // the attachment into "not encrypted".
   const attachments = await browser.messages.listAttachments(msgId);
-  if (attachments.some((att) => att.name === "postguard.encrypted")) return true;
+  if (detectPostGuard({ attachmentNames: attachments.map((att) => att.name) })) return true;
 
   try {
     const full = await browser.messages.getFull(msgId);
-    const bodyHtml = findHtmlBody(full);
-    if (bodyHtml && extractUploadUuid(bodyHtml)) return true;
+    return detectPostGuard({ htmlBody: findHtmlBody(full) ?? undefined });
   } catch {
     // Malformed messages / API errors mean "not detectable as encrypted",
     // not "throw". The caller falls back to the wasEncrypted check.
+    return false;
   }
-
-  return false;
 }
 
 /**

--- a/packages/pg-js/etc/pg-js.api.md
+++ b/packages/pg-js/etc/pg-js.api.md
@@ -26,6 +26,7 @@ export {
   type DecryptInput,
   type DecryptResult,
   DecryptionError,
+  type DetectPostGuardInput,
   type EncryptInput,
   type EnvelopeResult,
   type EnvelopeTier,
@@ -39,6 +40,9 @@ export {
   Opened,
   PG_MAX_ATTACHMENT_SIZE,
   PG_MAX_URL_FRAGMENT_SIZE,
+  POSTGUARD_ENCRYPTED_FILENAME,
+  type ParsedAttachment,
+  type ParsedMessage,
   PostGuard,
   type PostGuardConfig,
   PostGuardError,
@@ -60,12 +64,19 @@ export {
   YiviNotInstalledError,
   YiviSessionError,
   type YiviSign,
+  bodyFromMime,
   buildMime,
   createEnvelope,
   createZipReadable,
+  detectPostGuard,
+  extractArmoredCiphertext,
   extractCiphertext,
   extractUploadUuid,
   injectMimeHeaders,
+  isMultipart,
+  looksLikeArmoredPostGuard,
+  parseDecryptedMime,
+  readMimeHeader,
   resumeUpload,
 };
 
@@ -144,6 +155,11 @@ type DecryptResult = DecryptFileResult | DecryptDataResult;
 
 declare class DecryptionError extends PostGuardError {
     constructor(message: string, options?: ErrorOptions);
+}
+
+interface DetectPostGuardInput {
+    attachmentNames?: string[];
+    htmlBody?: string;
 }
 
 interface EmailAttributes {
@@ -236,6 +252,20 @@ declare class Opened {
 declare const PG_MAX_ATTACHMENT_SIZE: number;
 
 declare const PG_MAX_URL_FRAGMENT_SIZE = 100000;
+
+declare const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
+
+interface ParsedAttachment {
+    data: Uint8Array;
+    name: string;
+    type: string;
+}
+
+interface ParsedMessage {
+    attachments: ParsedAttachment[];
+    htmlBody: string | null;
+    plainBody: string | null;
+}
 
 declare class PostGuard extends PostGuardBase {
     encrypt(options: EncryptInput): Sealed;
@@ -420,17 +450,31 @@ interface YiviSign {
     type: 'yivi';
 }
 
+declare function bodyFromMime(rawMime: string): string;
+
 declare function buildMime(input: BuildMimeOptions): Uint8Array;
 
 declare function createEnvelope(options: CreateEnvelopeOptions): Promise<EnvelopeResult>;
 
 declare function createZipReadable(files: File[]): Promise<ReadableStream>;
 
+declare function detectPostGuard(input: DetectPostGuardInput): boolean;
+
+declare function extractArmoredCiphertext(htmlOrText: string): string | null;
+
 declare function extractCiphertext(options: ExtractCiphertextOptions): Uint8Array | null;
 
 declare function extractUploadUuid(html: string): string | null;
 
 declare function injectMimeHeaders(mime: string, headersToInject: Record<string, string>, headersToRemove?: string[]): string;
+
+declare function isMultipart(rawMime: string): boolean;
+
+declare function looksLikeArmoredPostGuard(htmlOrText: string): boolean;
+
+declare function parseDecryptedMime(rawMime: string): ParsedMessage;
+
+declare function readMimeHeader(rawMime: string, name: string): string | undefined;
 
 declare function resumeUpload(cryptifyUrl: string, uuid: string, recoveryToken: string, signal?: AbortSignal, headers?: HeadersInit): Promise<{
     state: FileState;

--- a/packages/pg-js/src/email/envelope.ts
+++ b/packages/pg-js/src/email/envelope.ts
@@ -1,6 +1,7 @@
 import type { CreateEnvelopeOptions, EnvelopeResult, EnvelopeTier } from '../types.js';
 import {
   toUrlSafeBase64,
+  POSTGUARD_ENCRYPTED_FILENAME,
   PG_MAX_URL_FRAGMENT_SIZE,
   PG_MAX_ATTACHMENT_SIZE,
 } from './extract.js';
@@ -170,7 +171,7 @@ export async function createEnvelope(options: CreateEnvelopeOptions): Promise<En
   const attachment =
     tier === 'tier3'
       ? null
-      : new File([encrypted as BlobPart], 'postguard.encrypted', {
+      : new File([encrypted as BlobPart], POSTGUARD_ENCRYPTED_FILENAME, {
           type: 'application/postguard; charset=utf-8',
         });
 

--- a/packages/pg-js/src/email/extract.ts
+++ b/packages/pg-js/src/email/extract.ts
@@ -11,15 +11,32 @@ export const PG_MAX_URL_FRAGMENT_SIZE = 100_000;
  *  limits while keeping a reasonable amount of mail self-contained. */
 export const PG_MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
 
+/** The attachment name every PostGuard envelope uses for the ciphertext, and
+ *  the marker installed mail clients key on. `createEnvelope` writes it and
+ *  every reader matches on it, so it is one constant rather than a literal
+ *  repeated across the SDK and both add-ins. Renaming it is a breaking change
+ *  for every message already delivered. */
+export const POSTGUARD_ENCRYPTED_FILENAME = 'postguard.encrypted';
+
+const ARMOR_BEGIN = '-----BEGIN POSTGUARD MESSAGE-----';
+const ARMOR_END = '-----END POSTGUARD MESSAGE-----';
+
 /** Extract ciphertext from a received email by looking for the
- *  `postguard.encrypted` attachment. Body-armor extraction is no longer
- *  supported — older messages with an armored block in the HTML body must
- *  also have shipped the matching attachment, and Tier 3 messages
- *  intentionally have no attachment (recipients use the Cryptify link
- *  in the body, surfaced via `extractUploadUuid`). */
+ *  `postguard.encrypted` attachment.
+ *
+ *  This does NOT look at the body. pg-js >= 1.1 stopped *emitting* the
+ *  in-body armor block, and messages written before that also shipped the
+ *  attachment, so the attachment is the only path a message this function is
+ *  given needs. Tier 3 messages intentionally have no attachment at all —
+ *  recipients use the Cryptify link, surfaced via `extractUploadUuid`.
+ *
+ *  For an archived message that carries *only* an armor block, use
+ *  `extractArmoredCiphertext` on the body. That path is separate on purpose:
+ *  it takes a string rather than attachments, and COMPATIBILITY.md's archival
+ *  guarantee is why it still exists at all. */
 export function extractCiphertext(options: ExtractCiphertextOptions): Uint8Array | null {
   if (options.attachments) {
-    const pgAtt = options.attachments.find((att) => att.name === 'postguard.encrypted');
+    const pgAtt = options.attachments.find((att) => att.name === POSTGUARD_ENCRYPTED_FILENAME);
     if (pgAtt) {
       return new Uint8Array(pgAtt.data);
     }
@@ -27,9 +44,75 @@ export function extractCiphertext(options: ExtractCiphertextOptions): Uint8Array
   return null;
 }
 
+/** Recover base64 ciphertext from an in-body ASCII armor block.
+ *
+ *  ARCHIVAL ONLY. Nothing has emitted this since pg-js 1.1 — it was dropped
+ *  because it pushed bodies past Outlook's 1 M-char `setAsync` limit, and that
+ *  drop is what broke Thunderbird detection in postguard-tb-addon#85. It stays
+ *  readable because COMPATIBILITY.md's archival guarantee is unconditional:
+ *  "read support for stored artifacts is not part of this window; it never
+ *  drops, whatever happens to the SDK version that wrote the bytes."
+ *
+ *  Do not add a caller that produces armor. Removing this function silently is
+ *  the same class of change as the one that caused tb#85, in the other
+ *  direction.
+ *
+ *  Returns the base64 payload with whitespace and any wrapping HTML tags
+ *  stripped, or null when no complete block is present. */
+export function extractArmoredCiphertext(htmlOrText: string): string | null {
+  if (!htmlOrText) return null;
+  const begin = htmlOrText.indexOf(ARMOR_BEGIN);
+  if (begin < 0) return null;
+  const end = htmlOrText.indexOf(ARMOR_END, begin);
+  if (end < 0) return null;
+  const block = htmlOrText.slice(begin + ARMOR_BEGIN.length, end);
+  return block.replace(/<[^>]+>/g, '').replace(/\s+/g, '');
+}
+
+/** True when an armor BEGIN marker is present, whether or not a complete block
+ *  follows. Lets a reader tell "this is a PostGuard message I cannot parse"
+ *  from "this is not a PostGuard message" and report the difference, rather
+ *  than failing silently. Archival only, as `extractArmoredCiphertext`. */
+export function looksLikeArmoredPostGuard(htmlOrText: string): boolean {
+  if (!htmlOrText) return false;
+  return htmlOrText.indexOf(ARMOR_BEGIN) >= 0;
+}
+
 /** Convert standard base64 to URL-safe base64 */
 export function toUrlSafeBase64(base64: string): string {
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** What a host has to gather about a message before PostGuard can classify it.
+ *  Both add-ins can produce this from their own API — `browser.messages
+ *  .listAttachments` in Thunderbird, `Office.context.mailbox.item` in Outlook —
+ *  and neither needs to know what makes a message PostGuard. */
+export interface DetectPostGuardInput {
+  /** Attachment names on the message, in any order. */
+  attachmentNames?: string[];
+  /** The message's HTML body, if the host can supply it cheaply. */
+  htmlBody?: string;
+}
+
+/** Decide whether a message is a PostGuard envelope the recipient can act on.
+ *
+ *  The three tiers do not look alike, and every host has to handle all three:
+ *  tier 1 and 2 carry the `postguard.encrypted` attachment, while tier 3 has
+ *  no attachment at all and is recognisable only by the Cryptify link in the
+ *  body. A host that checks the attachment alone silently fails to detect
+ *  every tier-3 message — the asymmetry behind #39.
+ *
+ *  Archived messages carrying only an in-body armor block also count: see
+ *  `extractArmoredCiphertext` for why that path is still supported. */
+export function detectPostGuard(input: DetectPostGuardInput): boolean {
+  if (input.attachmentNames?.some((name) => name === POSTGUARD_ENCRYPTED_FILENAME)) {
+    return true;
+  }
+  if (input.htmlBody) {
+    if (extractUploadUuid(input.htmlBody) !== null) return true;
+    if (looksLikeArmoredPostGuard(input.htmlBody)) return true;
+  }
+  return false;
 }
 
 /** Find a Cryptify UUID embedded in an email body. Looks for either of the

--- a/packages/pg-js/src/email/index.ts
+++ b/packages/pg-js/src/email/index.ts
@@ -26,7 +26,12 @@ export class EmailHelpers {
     return createEnvelopeImpl(options);
   }
 
-  /** Extract ciphertext from a received email (attachment or armored body) */
+  /** Extract ciphertext from the `postguard.encrypted` attachment of a received
+   *  email. It does not read the body: for an archived message carrying only an
+   *  in-body armor block use the standalone `extractArmoredCiphertext`, and for
+   *  tier 3 (no attachment at all) use `extractUploadUuid`. This doc previously
+   *  claimed "attachment or armored body", which the implementation has never
+   *  done. */
   extractCiphertext(options: ExtractCiphertextOptions): Uint8Array | null {
     return extractCiphertextImpl(options);
   }

--- a/packages/pg-js/src/email/parse.ts
+++ b/packages/pg-js/src/email/parse.ts
@@ -1,0 +1,222 @@
+// Reading the MIME message that comes back out of a decrypt.
+//
+// `buildMime` in ./mime.ts writes the inner message; this is the other half.
+// It lived in apps/outlook-addon/src/lib/mime.ts, where Thunderbird could not
+// reach it, so the two add-ins were drifting apart on the shape they agreed to
+// exchange (encryption4all/postguard-js#129).
+//
+// Deliberately NOT a general RFC 5322 parser. It handles what `buildMime`
+// produces and what mail clients do to it in transit: a single text part or a
+// multipart/* envelope, base64 and quoted-printable transfer encodings, folded
+// headers. Anything else is passed through rather than rejected — a reader
+// that throws on an unfamiliar message is worse than one that returns what it
+// could find, because the ciphertext is usually still recoverable.
+
+/** One attachment recovered from a decrypted MIME message. */
+export interface ParsedAttachment {
+  name: string;
+  type: string;
+  data: Uint8Array;
+}
+
+/** The user-facing content of a decrypted MIME message. */
+export interface ParsedMessage {
+  htmlBody: string | null;
+  plainBody: string | null;
+  attachments: ParsedAttachment[];
+}
+
+interface RawPart {
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** Read a single header value by name, case-insensitively, from a raw MIME
+ *  blob. Continuation lines are unfolded first, so a header split across lines
+ *  by a sending client reads back as one value. Returns undefined when absent. */
+export function readMimeHeader(rawMime: string, name: string): string | undefined {
+  if (!rawMime) return undefined;
+  const lcName = name.toLowerCase();
+  // The header section ends at the first blank line, CRLF or LF: a body
+  // containing something that looks like a header must not be searched.
+  const headerEnd = rawMime.search(/\r?\n\r?\n/);
+  const headerSection = headerEnd >= 0 ? rawMime.slice(0, headerEnd) : rawMime;
+  const unfolded = headerSection.replace(/\r?\n[ \t]+/g, ' ');
+  for (const line of unfolded.split(/\r?\n/)) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    if (line.slice(0, idx).trim().toLowerCase() === lcName) {
+      return line.slice(idx + 1).trim();
+    }
+  }
+  return undefined;
+}
+
+/** Strip the header block and return the body. For a multipart message this is
+ *  the raw multipart body including boundaries — use `parseDecryptedMime` when
+ *  you want the parts. */
+export function bodyFromMime(rawMime: string): string {
+  const headerEnd = rawMime.search(/\r?\n\r?\n/);
+  return headerEnd >= 0 ? rawMime.slice(headerEnd).replace(/^\r?\n\r?\n/, '') : rawMime;
+}
+
+/** True when the message declares a `multipart/*` Content-Type. */
+export function isMultipart(rawMime: string): boolean {
+  const ct = readMimeHeader(rawMime, 'Content-Type') ?? '';
+  return /^multipart\//i.test(ct);
+}
+
+/** Pull the user-facing body and any attachments out of a decrypted MIME blob.
+ *
+ *  Handles a single text part or a nested multipart/* envelope, and decodes
+ *  base64 and quoted-printable. Other transfer encodings (7bit, 8bit, binary)
+ *  are already the bytes they claim to be and pass through untouched. */
+export function parseDecryptedMime(rawMime: string): ParsedMessage {
+  const result: ParsedMessage = { htmlBody: null, plainBody: null, attachments: [] };
+  collectParts(rawMime, result);
+  return result;
+}
+
+function splitHeadersAndBody(raw: string): RawPart {
+  const headerEnd = raw.search(/\r?\n\r?\n/);
+  if (headerEnd < 0) return { headers: {}, body: raw };
+  const headerSection = raw.slice(0, headerEnd);
+  const body = raw.slice(headerEnd).replace(/^\r?\n\r?\n/, '');
+  const unfolded = headerSection.replace(/\r?\n[ \t]+/g, ' ');
+  const headers: Record<string, string> = {};
+  for (const line of unfolded.split(/\r?\n/)) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const name = line.slice(0, idx).trim().toLowerCase();
+    headers[name] = line.slice(idx + 1).trim();
+  }
+  return { headers, body };
+}
+
+function collectParts(raw: string, out: ParsedMessage): void {
+  const part = splitHeadersAndBody(raw);
+  const ct = part.headers['content-type'] ?? 'text/plain';
+  const ctMain = ct.split(';')[0].trim().toLowerCase();
+
+  if (ctMain.startsWith('multipart/')) {
+    const boundary = paramFromHeader(ct, 'boundary');
+    if (!boundary) return;
+    for (const child of splitByBoundary(part.body, boundary)) {
+      collectParts(child, out);
+    }
+    return;
+  }
+
+  const cd = part.headers['content-disposition'] ?? '';
+  const cte = (part.headers['content-transfer-encoding'] ?? '7bit').toLowerCase();
+  const filename = paramFromHeader(cd, 'filename') ?? paramFromHeader(ct, 'name');
+  const isAttachment = /attachment/i.test(cd) || (filename != null && !ctMain.startsWith('text/'));
+
+  if (isAttachment) {
+    out.attachments.push({
+      name: filename ?? 'attachment',
+      type: ctMain,
+      data: decodeToBytes(part.body, cte),
+    });
+    return;
+  }
+
+  const text = decodeToString(part.body, cte);
+  if (ctMain === 'text/html' && out.htmlBody == null) {
+    out.htmlBody = text;
+  } else if (ctMain === 'text/plain' && out.plainBody == null) {
+    out.plainBody = text;
+  } else if (out.htmlBody == null && out.plainBody == null) {
+    // Text-ish but an unfamiliar type. Surfacing it as plain beats dropping it.
+    out.plainBody = text;
+  }
+}
+
+function paramFromHeader(value: string, name: string): string | null {
+  const re = new RegExp(`(?:^|;)\\s*${name}\\s*=\\s*"?([^";]+)"?`, 'i');
+  const m = value.match(re);
+  return m ? m[1].trim() : null;
+}
+
+function splitByBoundary(body: string, boundary: string): string[] {
+  const escaped = boundary.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Boundaries sit on their own line as --boundary, with --boundary-- closing
+  // the set. Split on either, then drop the preamble before the first boundary
+  // and the epilogue after the close, neither of which is a part.
+  const re = new RegExp(`(?:^|\\r?\\n)--${escaped}(?:--)?[^\\n]*\\r?\\n?`, 'g');
+  const pieces = body.split(re);
+  return pieces.slice(1).filter((p) => p.length > 0);
+}
+
+function decodeToBytes(body: string, encoding: string): Uint8Array {
+  if (encoding === 'base64') {
+    const cleaned = body.replace(/\s/g, '');
+    try {
+      const bin = atob(cleaned);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return bytes;
+    } catch {
+      // Truncated or corrupt base64. An empty attachment is recoverable for
+      // the caller; a throw here would lose the rest of the message too.
+      return new Uint8Array();
+    }
+  }
+  if (encoding === 'quoted-printable') {
+    return decodeQuotedPrintable(body);
+  }
+  return new TextEncoder().encode(body);
+}
+
+function decodeToString(body: string, encoding: string): string {
+  if (encoding === 'base64') {
+    const cleaned = body.replace(/\s/g, '');
+    try {
+      const bin = atob(cleaned);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return new TextDecoder('utf-8').decode(bytes);
+    } catch {
+      return body;
+    }
+  }
+  if (encoding === 'quoted-printable') {
+    return new TextDecoder('utf-8').decode(decodeQuotedPrintable(body));
+  }
+  return body;
+}
+
+/** Decode quoted-printable to BYTES, not to a string.
+ *
+ *  Each `=XX` is one octet, and a non-ASCII character is sent as a *sequence*
+ *  of them — `café` is `caf=C3=A9`. Mapping each octet through
+ *  `String.fromCharCode` yields one character per byte, so that reads back as
+ *  `cafÃ©`: every accented character in a quoted-printable body came out
+ *  mojibake, and the byte path then re-encoded that as UTF-8 and doubled it.
+ *  Collecting octets and decoding once at the end is the only way to get the
+ *  multi-byte sequences back.
+ *
+ *  Carried over from apps/outlook-addon with the bug fixed (#129); the
+ *  round-trip test in tests/parse.test.ts is what caught it. */
+function decodeQuotedPrintable(s: string): Uint8Array {
+  // Soft line breaks first: they are `=` at end of line and encode nothing.
+  const unfolded = s.replace(/=\r?\n/g, '');
+  const out: number[] = [];
+  for (let i = 0; i < unfolded.length; i++) {
+    const ch = unfolded[i];
+    if (ch === '=' && /^[0-9A-F]{2}$/i.test(unfolded.slice(i + 1, i + 3))) {
+      out.push(parseInt(unfolded.slice(i + 1, i + 3), 16));
+      i += 2;
+      continue;
+    }
+    const code = ch.charCodeAt(0);
+    if (code < 0x80) {
+      out.push(code);
+    } else {
+      // Not legal quoted-printable — a lenient sender left raw UTF-8 in the
+      // body. Keep it rather than mangling it to a single byte.
+      for (const b of new TextEncoder().encode(ch)) out.push(b);
+    }
+  }
+  return new Uint8Array(out);
+}

--- a/packages/pg-js/src/index.ts
+++ b/packages/pg-js/src/index.ts
@@ -55,10 +55,24 @@ export { buildMime, injectMimeHeaders } from './email/mime.js';
 export {
   extractCiphertext,
   extractUploadUuid,
+  extractArmoredCiphertext,
+  looksLikeArmoredPostGuard,
+  detectPostGuard,
+  POSTGUARD_ENCRYPTED_FILENAME,
   PG_MAX_URL_FRAGMENT_SIZE,
   PG_MAX_ATTACHMENT_SIZE,
 } from './email/extract.js';
+export type { DetectPostGuardInput } from './email/extract.js';
 export { createEnvelope } from './email/envelope.js';
+// Reading a decrypted message back. The other half of buildMime, shared by both
+// add-ins so they cannot drift on the shape they exchange (#129).
+export {
+  parseDecryptedMime,
+  readMimeHeader,
+  bodyFromMime,
+  isMultipart,
+} from './email/parse.js';
+export type { ParsedMessage, ParsedAttachment } from './email/parse.js';
 
 // Errors
 export {

--- a/packages/pg-js/tests/detect.test.ts
+++ b/packages/pg-js/tests/detect.test.ts
@@ -1,0 +1,94 @@
+// Detection and the archival armor readers, consolidated in #129.
+//
+// Detection used to live in each add-in, which is how tier 3 came to be handled
+// inconsistently: a host that checks only for the attachment misses every
+// message whose ciphertext is in Cryptify (#39).
+
+import { describe, expect, it } from 'vitest';
+import {
+  POSTGUARD_ENCRYPTED_FILENAME,
+  detectPostGuard,
+  extractArmoredCiphertext,
+  looksLikeArmoredPostGuard,
+} from '../src/email/extract.js';
+
+const ARMOR_BEGIN = '-----BEGIN POSTGUARD MESSAGE-----';
+const ARMOR_END = '-----END POSTGUARD MESSAGE-----';
+
+describe('detectPostGuard', () => {
+  it('detects tier 1 and 2 by the attachment name', () => {
+    expect(detectPostGuard({ attachmentNames: [POSTGUARD_ENCRYPTED_FILENAME] })).toBe(true);
+    expect(detectPostGuard({ attachmentNames: ['report.pdf', POSTGUARD_ENCRYPTED_FILENAME] })).toBe(
+      true
+    );
+  });
+
+  it('detects tier 3, which ships no attachment at all', () => {
+    // The whole reason this predicate is shared. A host checking only the
+    // attachment silently fails to detect every tier-3 message.
+    expect(
+      detectPostGuard({
+        attachmentNames: [],
+        htmlBody: '<a href="https://postguard.eu/decrypt?uuid=abc-123">Decrypt</a>',
+      })
+    ).toBe(true);
+    expect(
+      detectPostGuard({ htmlBody: '<a href="https://postguard.eu/download?uuid=xyz">Get</a>' })
+    ).toBe(true);
+  });
+
+  it('detects an archived armor-only message', () => {
+    expect(detectPostGuard({ htmlBody: `<pre>${ARMOR_BEGIN}\nZm9v\n${ARMOR_END}</pre>` })).toBe(
+      true
+    );
+  });
+
+  it('says no for an ordinary message', () => {
+    expect(detectPostGuard({})).toBe(false);
+    expect(detectPostGuard({ attachmentNames: [], htmlBody: '' })).toBe(false);
+    expect(
+      detectPostGuard({
+        attachmentNames: ['invoice.pdf'],
+        htmlBody: '<p>See attached, and visit https://postguard.eu for details.</p>',
+      })
+    ).toBe(false);
+  });
+
+  it('does not match a near-miss attachment name', () => {
+    expect(detectPostGuard({ attachmentNames: ['postguard.encrypted.txt'] })).toBe(false);
+    expect(detectPostGuard({ attachmentNames: ['POSTGUARD.ENCRYPTED'] })).toBe(false);
+  });
+});
+
+describe('extractArmoredCiphertext', () => {
+  it('recovers the payload and strips whitespace', () => {
+    const body = `${ARMOR_BEGIN}\nZm9v\nYmFy\n${ARMOR_END}`;
+    expect(extractArmoredCiphertext(body)).toBe('Zm9vYmFy');
+  });
+
+  it('strips HTML tags a mail client wrapped around the block', () => {
+    const body = `<div>${ARMOR_BEGIN}<br>Zm9v<br>YmFy<br>${ARMOR_END}</div>`;
+    expect(extractArmoredCiphertext(body)).toBe('Zm9vYmFy');
+  });
+
+  it('returns null when the block is absent or unterminated', () => {
+    expect(extractArmoredCiphertext('')).toBeNull();
+    expect(extractArmoredCiphertext('<p>ordinary mail</p>')).toBeNull();
+    expect(extractArmoredCiphertext(`${ARMOR_BEGIN}\nZm9v`)).toBeNull();
+  });
+});
+
+describe('looksLikeArmoredPostGuard', () => {
+  it('is true for a truncated block that extract cannot parse', () => {
+    const truncated = `${ARMOR_BEGIN}\nZm9v`;
+    // The pair matters: this is how a reader reports "PostGuard message I
+    // cannot read" instead of treating it as ordinary mail and saying nothing.
+    expect(looksLikeArmoredPostGuard(truncated)).toBe(true);
+    expect(extractArmoredCiphertext(truncated)).toBeNull();
+  });
+
+  it('is false for ordinary mail', () => {
+    expect(looksLikeArmoredPostGuard('')).toBe(false);
+    expect(looksLikeArmoredPostGuard('<p>hello</p>')).toBe(false);
+  });
+});

--- a/packages/pg-js/tests/parse.test.ts
+++ b/packages/pg-js/tests/parse.test.ts
@@ -1,0 +1,190 @@
+// Coverage for the MIME reader consolidated out of apps/outlook-addon in #129.
+// It shipped in the add-on with no tests at all, which is part of why the two
+// add-ins were free to drift; a round-trip against buildMime is the check that
+// actually holds the two halves together.
+
+import { describe, expect, it } from 'vitest';
+import { buildMime } from '../src/email/mime.js';
+import {
+  bodyFromMime,
+  isMultipart,
+  parseDecryptedMime,
+  readMimeHeader,
+} from '../src/email/parse.js';
+
+const CRLF = '\r\n';
+
+function utf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+describe('readMimeHeader', () => {
+  const raw = ['Subject: hello', 'X-PostGuard: 0.1', 'To: a@example.com', '', 'body'].join(CRLF);
+
+  it('reads a header case-insensitively', () => {
+    expect(readMimeHeader(raw, 'subject')).toBe('hello');
+    expect(readMimeHeader(raw, 'SUBJECT')).toBe('hello');
+    expect(readMimeHeader(raw, 'X-PostGuard')).toBe('0.1');
+  });
+
+  it('returns undefined for an absent header rather than throwing', () => {
+    expect(readMimeHeader(raw, 'Reply-To')).toBeUndefined();
+    expect(readMimeHeader('', 'Subject')).toBeUndefined();
+  });
+
+  it('unfolds a header split across continuation lines', () => {
+    const folded = ['References: <one@x>', ' <two@x>', '', 'body'].join(CRLF);
+    expect(readMimeHeader(folded, 'References')).toBe('<one@x> <two@x>');
+  });
+
+  it('does not read a header-shaped line out of the body', () => {
+    const withBody = ['Subject: real', '', 'Subject: not-a-header'].join(CRLF);
+    expect(readMimeHeader(withBody, 'Subject')).toBe('real');
+  });
+});
+
+describe('bodyFromMime and isMultipart', () => {
+  it('strips the header block', () => {
+    const raw = ['Subject: x', '', 'line one', 'line two'].join(CRLF);
+    expect(bodyFromMime(raw)).toBe(`line one${CRLF}line two`);
+  });
+
+  it('returns the input unchanged when there is no header separator', () => {
+    expect(bodyFromMime('just a body')).toBe('just a body');
+  });
+
+  it('detects a multipart content type', () => {
+    const multi = ['Content-Type: multipart/mixed; boundary="b"', '', ''].join(CRLF);
+    const single = ['Content-Type: text/html; charset=utf-8', '', 'hi'].join(CRLF);
+    expect(isMultipart(multi)).toBe(true);
+    expect(isMultipart(single)).toBe(false);
+    expect(isMultipart('')).toBe(false);
+  });
+});
+
+describe('parseDecryptedMime', () => {
+  it('round-trips a buildMime message with attachments', () => {
+    const data = new Uint8Array([1, 2, 3, 250, 0, 128]);
+    const mime = utf8(
+      buildMime({
+        from: 'sender@example.com',
+        to: ['rcpt@example.com'],
+        subject: 'Round trip',
+        htmlBody: '<p>hello</p>',
+        attachments: [{ name: 'notes.txt', type: 'text/plain', data: data.buffer }],
+      })
+    );
+
+    const parsed = parseDecryptedMime(mime);
+
+    expect(parsed.htmlBody).toContain('<p>hello</p>');
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].name).toBe('notes.txt');
+    // The bytes matter more than the text: this is the path a decrypted
+    // attachment takes back to the user.
+    expect(Array.from(parsed.attachments[0].data)).toEqual(Array.from(data));
+  });
+
+  it('reads a single-part html message', () => {
+    const mime = ['Content-Type: text/html; charset=utf-8', '', '<p>only body</p>'].join(CRLF);
+    const parsed = parseDecryptedMime(mime);
+    expect(parsed.htmlBody).toBe('<p>only body</p>');
+    expect(parsed.plainBody).toBeNull();
+    expect(parsed.attachments).toEqual([]);
+  });
+
+  it('decodes quoted-printable text', () => {
+    const mime = [
+      'Content-Type: text/plain; charset=utf-8',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      'caf=C3=A9 and a soft=',
+      ' break',
+    ].join(CRLF);
+    expect(parseDecryptedMime(mime).plainBody).toContain('café');
+  });
+
+  it('decodes quoted-printable attachment bytes as octets, not as characters', () => {
+    // The other half of the same bug: the byte path used to take the
+    // one-char-per-octet string and UTF-8 encode it, so every octet above 0x7f
+    // came back as two bytes and the attachment was silently corrupted.
+    const mime = [
+      'Content-Type: application/octet-stream; name="raw.bin"',
+      'Content-Disposition: attachment; filename="raw.bin"',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      '=00=C3=A9=FF',
+    ].join(CRLF);
+
+    const [att] = parseDecryptedMime(mime).attachments;
+    expect(Array.from(att.data)).toEqual([0x00, 0xc3, 0xa9, 0xff]);
+  });
+
+  it('decodes base64 text', () => {
+    const mime = [
+      'Content-Type: text/plain',
+      'Content-Transfer-Encoding: base64',
+      '',
+      btoa('decoded body'),
+    ].join(CRLF);
+    expect(parseDecryptedMime(mime).plainBody).toBe('decoded body');
+  });
+
+  it('recurses into a nested multipart envelope', () => {
+    const inner = [
+      '--inner',
+      'Content-Type: text/plain',
+      '',
+      'plain part',
+      '--inner',
+      'Content-Type: text/html',
+      '',
+      '<p>html part</p>',
+      '--inner--',
+    ].join(CRLF);
+    const mime = [
+      'Content-Type: multipart/mixed; boundary="outer"',
+      '',
+      '--outer',
+      'Content-Type: multipart/alternative; boundary="inner"',
+      '',
+      inner,
+      '--outer--',
+    ].join(CRLF);
+
+    const parsed = parseDecryptedMime(mime);
+    expect(parsed.plainBody).toBe('plain part');
+    expect(parsed.htmlBody).toBe('<p>html part</p>');
+  });
+
+  it('survives corrupt base64 in an attachment instead of losing the message', () => {
+    const mime = [
+      'Content-Type: multipart/mixed; boundary="b"',
+      '',
+      '--b',
+      'Content-Type: text/html',
+      '',
+      '<p>body survives</p>',
+      '--b',
+      'Content-Type: application/octet-stream; name="broken.bin"',
+      'Content-Disposition: attachment; filename="broken.bin"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      '!!!not base64!!!',
+      '--b--',
+    ].join(CRLF);
+
+    const parsed = parseDecryptedMime(mime);
+    // The point: the html body is still recovered. A throwing parser would
+    // take the readable part of the message down with the unreadable one.
+    expect(parsed.htmlBody).toBe('<p>body survives</p>');
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].data).toHaveLength(0);
+  });
+
+  it('treats a boundary-less multipart as empty rather than throwing', () => {
+    const mime = ['Content-Type: multipart/mixed', '', 'orphaned'].join(CRLF);
+    const parsed = parseDecryptedMime(mime);
+    expect(parsed).toEqual({ htmlBody: null, plainBody: null, attachments: [] });
+  });
+});


### PR DESCRIPTION
Part of #129 (the second of its three parts). `apps/outlook-addon` carried 225 lines of hand-rolled multipart parsing and `apps/tb-addon` carried its own detection, so the two hosts agreed on the shape they exchange only by coincidence. Both now read the envelope through the SDK.

Lands on top of the envelope-compat gate (#153) deliberately: the gate is live for every commit here, which is the whole point of that ordering.

## Moved into pg-js

`parseDecryptedMime`, `readMimeHeader`, `bodyFromMime`, `isMultipart`, `detectPostGuard`, `extractArmoredCiphertext`, `looksLikeArmoredPostGuard`, `POSTGUARD_ENCRYPTED_FILENAME`, plus the `ParsedMessage` / `ParsedAttachment` / `DetectPostGuardInput` types.

Additive only — the API report diff is **44 insertions, no removals**, so the changeset is `minor`.

## The armor asymmetry, resolved rather than deleted

`extract.ts` said body-armor extraction was "no longer supported" while Outlook still shipped `extractArmoredCiphertext` and used it as a live fallback in `tryFindCiphertext`. Both were right about different things: the comment described the **emitter** (pg-js >= 1.1 stopped writing armor — the change behind postguard-tb-addon#85) but stated it as a property of the **reader**.

`COMPATIBILITY.md`'s archival guarantee is unconditional — "read support for stored artifacts is not part of this window; it never drops" — so deleting Outlook's copy would have been the tb#85 change again in the other direction. Armor reading is promoted into the SDK as an explicitly archival export instead, with a comment saying not to add a caller that produces it.

Related: `EmailHelpers.extractCiphertext`'s JSDoc claimed it read "attachment or armored body". It has only ever read the attachment. Corrected.

## Two bugs the move surfaced

**Quoted-printable was decoded one character per octet.** `decodeQuotedPrintable` mapped each `=XX` through `String.fromCharCode`, so `caf=C3=A9` came back as `cafÃ©` — every accented character in a quoted-printable body was mojibake. The byte path then UTF-8-encoded that string, doubling every octet above `0x7f` and silently corrupting quoted-printable attachments. Octets are now collected and decoded once, and both halves are pinned by tests:

```
expect(parseDecryptedMime(mime).plainBody).toContain("café")
expect(Array.from(att.data)).toEqual([0x00, 0xc3, 0xa9, 0xff])
```

Caught by the round-trip test, not by reading the code — it was moved verbatim first, and the test failed.

**`postguard.encrypted` was a literal in five places**, including one in `tb-addon` independent of the SDK's own. One exported constant now, used by the emitter and every reader.

## What stayed host-specific

- `guessContentType` is Office.js glue: it exists because Office.js hands back an attachment name and no Content-Type. No other host has that gap.
- `detection.ts` keeps its WebExtension calls, and still checks attachments **before** pulling the body — folding both into one `detectPostGuard` call would fetch the full message every time, and would turn a `getFull` failure on a message that *does* carry the attachment into "not encrypted".

## Tests

The moved parser had **no tests** in the add-on, which is part of how the two copies were free to drift. 25 added, including a `buildMime` → `parseDecryptedMime` round-trip that holds the two halves of the format together, nested-multipart recursion, and a corrupt-base64 case asserting the readable part of a message survives an unreadable attachment.

`pnpm -r typecheck`, `build` and `test` green: 330 pg-js (was 305), 39 outlook, 212 tb-addon, 20 website. Envelope gate green, API report matches.

## Still open in #129

Part 3, the `x-postguard` semantics. Four producers disagree and detection is a bare presence check, so no test can arbitrate it until the meaning is decided — untouched here.