### PR TITLE
docs(outlook-addon): describe the workspace release flow, not the archived repo's

### DIFF
--- a/apps/outlook-addon/README.md
+++ b/apps/outlook-addon/README.md
@@ -31,15 +31,29 @@ import deliberately left behind; B4 part two ports them (encryption4all/postguar
 
 ## Releasing
 
-Releases are automated via [release-please](https://github.com/googleapis/release-please) using [Conventional Commits](https://www.conventionalcommits.org/). The flow:
+Releases run from this workspace via `.github/workflows/outlook-addon.yml`, using
+[changesets](https://github.com/changesets/changesets). The release-please flow this
+section used to describe belonged to the standalone `encryption4all/postguard-outlook-addon`
+repo, which is archived — there is no `master` branch and no `Release` workflow to run.
 
-1. Merge PRs to `master` with conventional commit messages (`feat:`, `fix:`, …).
-2. The `Release` workflow runs and release-please opens — or updates — a release PR titled `chore(main): release X.Y.Z`.
-3. Merging that release PR creates the `vX.Y.Z` tag, builds and pushes the production Docker image to `ghcr.io/encryption4all/postguard-outlook-addon:X.Y.Z` (and `:latest`), and uploads `dist/manifest.xml` to the GitHub Release as a sideloadable asset.
+1. Add a changeset describing the change. It bumps `package.json` only, so
+   `pnpm --filter postguard-outlook-addin sync-version` propagates the version into
+   `manifest.xml`'s `<Version>`.
+2. Merging the `Version Packages` PR lands the bumped version on `main`.
+3. Pushing the app-scoped tag `outlook-addin-vX.Y.Z` builds and pushes the production
+   Docker image to `ghcr.io/encryption4all/postguard-outlook-addon:X.Y.Z`, and creates the
+   GitHub Release carrying `manifest.xml` as a sideloadable asset.
 
-Non-release pushes to `master` build a staging image tagged `:edge` (and `:sha-<commit>`) hosted at `addin.staging.postguard.eu`.
+The tag is `outlook-addin-v*`, never `vX.Y.Z`: this repo's tag namespace is shared with
+`@e4a/pg-js`'s changesets releases and still holds the pre-monorepo `v2.3.3`-style pg-js
+tags, so a bare `v*` would collide with another package's release.
 
-If you want to cut a release whose commits are all `chore:` (release-please skips those by default for `0.x` versions), push a commit to master with a `Release-As: X.Y.Z` footer to force the next release.
+Non-release pushes to `main` build a staging image tagged `:edge` (and `:sha-<commit>`)
+hosted at `addin.staging.postguard.eu`.
+
+Point any sideload or admin-center deployment at the `outlook-addin-v*` releases here. The
+archived repo's `releases/latest/download/manifest.xml` still resolves and still serves
+v0.5.0, and always will — an archived repo keeps serving its release assets.
 
 ## License
 


### PR DESCRIPTION
Follow-on to #224, from the same audit (encryption4all/postguard#312). The final sweep caught one more page describing a channel that no longer exists.

`apps/outlook-addon/README.md`'s **Releasing** section still documented the standalone repo's process: release-please on a `master` branch, a `Release` workflow, `chore(main): release X.Y.Z` PRs, `vX.Y.Z` tags, a `:latest` image push, and a `Release-As:` footer escape hatch. `encryption4all/postguard-outlook-addon` is archived — there is no `master` branch here and that workflow cannot run — so anyone following these steps is following instructions into a read-only repo.

Replaced with what `.github/workflows/outlook-addon.yml` actually does: changesets sets the version, `sync-version` propagates it into `manifest.xml`'s `<Version>`, and pushing the app-scoped tag `outlook-addin-vX.Y.Z` builds the production image and creates the release carrying `manifest.xml`. Records why the tag is app-scoped rather than `v*` (shared namespace with `@e4a/pg-js`'s changesets releases plus the pre-monorepo `v2.3.3`-style tags).

Also states where sideload and admin-center deployments should point, and that the archived repo's `releases/latest/download/manifest.xml` still resolves, still serves v0.5.0, and always will.

Docs only.