### PR TITLE
ci(tb-addon): check formatting in CI, not only in the pre-commit hook

### DIFF
--- a/.github/workflows/tb-addon.yml
+++ b/.github/workflows/tb-addon.yml
@@ -45,7 +45,7 @@ jobs:
             # `.husky/pre-commit` runs lint-staged over this app, but a hook only
             # ever sees staged files and `--no-verify` skips it entirely, so until
             # this step existed the formatting rule was a convention rather than a
-            # contract. `pnpm lint` is `prettier --check .`, package-wide, which is
+            # contract. The step below runs `prettier --check .`, package-wide, which is
             # wider than the hook's globs — a CI gate narrower than the hook it
             # complements is strictly weaker than it looks. It runs before the
             # build, and apps/tb-addon/.gitignore keeps `dist/` out either way,

--- a/.github/workflows/tb-addon.yml
+++ b/.github/workflows/tb-addon.yml
@@ -42,6 +42,22 @@ jobs:
             - run: pnpm install --frozen-lockfile
               working-directory: .
 
+            # `.husky/pre-commit` runs lint-staged over this app, but a hook only
+            # ever sees staged files and `--no-verify` skips it entirely, so until
+            # this step existed the formatting rule was a convention rather than a
+            # contract. `pnpm lint` is `prettier --check .`, package-wide, which is
+            # wider than the hook's globs — a CI gate narrower than the hook it
+            # complements is strictly weaker than it looks. It runs before the
+            # build, and apps/tb-addon/.gitignore keeps `dist/` out either way,
+            # which prettier honours as a default ignore path.
+            #
+            # A step rather than a job, deliberately: it reports under this job's
+            # existing required `Build & test` context, so it needs no entry in the
+            # `main` ruleset or in REQUIRED_CONTEXTS. A new job would be a new
+            # context, unenforced until both are updated in lockstep.
+            - name: Prettier (format check)
+              run: pnpm lint
+
             # changesets bumps package.json only; Thunderbird reads manifest.json
             # and the update channel reads updates.json. The release job below
             # refuses a mismatched tag, so catch the drift on the PR instead.


### PR DESCRIPTION
Closes encryption4all/postguard#324 (cross-repo, so it will not auto-close — please close it on merge).

## The gap

[#138](https://github.com/encryption4all/postguard-js/issues/138) gave `apps/tb-addon` prettier, a `lint-staged` block and a `.husky/pre-commit` line, but `tb-addon.yml` had **no lint step**. So the hook was the only enforcement, and a hook only ever sees staged files — `--no-verify`, or any commit path that skips hooks, landed unformatted code and nothing reported it. `apps/website` and `apps/outlook-addon` already have CI lint lanes; this closes the last app-level asymmetry.

## Step, not a job

One step in the existing `build` job, after `pnpm install`:

```yaml
- name: Prettier (format check)
  run: pnpm lint
```

As a step it reports under the existing required **`Build & test`** context, so it needs no change to the `main` ruleset (id `14326269`) and no edit to `REQUIRED_CONTEXTS` in `packages/pg-js/tests/ci-wiring.test.ts`. Split into its own job it would be a new context, enforcing nothing until both were updated in lockstep — the drift [#222](https://github.com/encryption4all/postguard-js/issues/222) exists to catch.

No `working-directory`: the workflow already defaults to `apps/tb-addon`, which is also the directory whose prettier config and `.gitignore` apply.

## Verified against `origin/main` (`5b52288`)

- The premise still holds — `tb-addon.yml` had no lint/prettier step, and `apps/tb-addon` still declares `"lint": "prettier --check ."`.
- `pnpm lint` **passes clean** on a fresh tree, so the [#138](https://github.com/encryption4all/postguard-js/issues/138) reformat was complete and this step goes green on arrival rather than red.
- It genuinely gates: with an unformatted file planted under `src/`, `pnpm lint` fails with exit 1.
- The whole `build` job still passes locally in order — `lint`, `check-version`, `typecheck`, `test`.
- The `ci-wiring` guard is green (14/14), and parsing the edited YAML confirms the step lands at index 4 (immediately after `pnpm install`), carries no `working-directory`, and sits in the job named `Build & test`.

## One thing found on the way

`.github/workflows/*.yml` is **not** covered by any prettier config — `prettier --check` on `tb-addon.yml` fails on `origin/main` today, unchanged by this PR. That is deliberate per the comment in `.husky/pre-commit` (a config at the repo root would silently become the style of every package that has none), so this edit matches the file's own 4-space style rather than prettier's. Worth knowing, not worth fixing here; it belongs with [#323](https://github.com/encryption4all/postguard/issues/323) if anywhere.