### PR TITLE
ci: apply the two workflow patches #270 could not push

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -49,9 +49,9 @@ jobs:
             # script, silently and with a zero exit — that is how the website and
             # the Outlook add-in both shipped without a typecheck. `typecheck` is
             # the one script every example must therefore declare, and this asserts
-            # it rather than trusting it. `build` and `lint` are genuinely absent in
-            # some examples (pg-node runs, it does not build), so they stay
-            # best-effort below.
+            # it rather than trusting it, as does the `lint` guard below it. `build`
+            # is genuinely absent in some examples (pg-node runs, it does not
+            # build), so it stays best-effort.
             - name: Every example declares typecheck
               shell: bash
               run: |
@@ -88,6 +88,32 @@ jobs:
             - name: Build
               run: pnpm --filter './examples/*' run build
 
+            # Until this guard existed the step below was fail-open: pnpm skipped
+            # the two examples declaring no `lint` script and exited 0, so `Lint`
+            # was green while linting one example of three.
+            - name: Every example declares lint
+              shell: bash
+              run: |
+                  set -uo pipefail
+                  missing=0 count=0
+                  for pkg in examples/*/package.json; do
+                    [ -f "$pkg" ] || continue
+                    count=$((count + 1))
+                    if ! jq -e '.scripts.lint // "" | length > 0' "$pkg" >/dev/null 2>&1; then
+                      echo "::error::$pkg declares no \"lint\" script; pnpm would skip it without a word"
+                      missing=1
+                    fi
+                  done
+                  if [ "$count" -eq 0 ]; then
+                    echo "::error::found no examples/*/package.json; this job would pass vacuously"
+                    exit 1
+                  fi
+                  if [ "$missing" -ne 0 ]; then
+                    exit 1
+                  fi
+                  echo "$count example packages, each declaring lint"
+
+            # Asserted present above, so this cannot skip silently.
             - name: Lint
               run: pnpm --filter './examples/*' run lint
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,21 @@ jobs:
             - name: Prettier plugins resolve from the root
               run: pnpm check-prettier-plugins
 
+            # `.husky/pre-commit` runs lint-staged over packages/pg-js, but a hook
+            # only ever sees staged files and `--no-verify` skips it entirely, so
+            # without this step the SDK's formatting rule is a convention rather
+            # than a contract. Same shape as the tb-addon lane: `prettier --check .`
+            # package-wide, which is wider than the hook's globs, because a CI gate
+            # narrower than the hook it complements is weaker than it looks.
+            #
+            # A step rather than a job, deliberately: it reports under this job's
+            # `Integration complete` aggregate, which is already required, so it
+            # needs no `main` ruleset change and no REQUIRED_CONTEXTS edit in
+            # packages/pg-js/tests/ci-wiring.test.ts. A new job would be a new
+            # context, unenforced until both are updated in lockstep.
+            - name: Prettier (format check)
+              run: pnpm --filter @e4a/pg-js lint
+
             - name: Typecheck
               run: pnpm -r typecheck
 


### PR DESCRIPTION
Applies the two workflow patches [#270](https://github.com/encryption4all/postguard-js/pull/270) could not push. Follows up #269, which is already closed.

## What happened

`dobby-coder` has no `workflows: write`, so #270 left both halves as paste-ready patches on #269 ([patch 1](https://github.com/encryption4all/postguard-js/issues/269#issuecomment-5478265184), [patch 2](https://github.com/encryption4all/postguard-js/issues/269#issuecomment-5478265477)) and said so in [a PR comment](https://github.com/encryption4all/postguard-js/pull/270#issuecomment-5478266). The handover was done exactly right — correct patches, real URLs, flagged on the PR. It merged anyway with neither applied, closing #269 by trailer, and **CI was green the whole way**.

**Why nothing caught it.** `packages/pg-js/tests/ci-wiring.test.ts` is this repo's guard against exactly this — an unapplied workflow patch merging green. It asserts **jobs and required contexts**, not the steps inside them. Both patches add steps to jobs that already exist, chosen that way deliberately so they report under an already-required aggregate and need no ruleset change and no `REQUIRED_CONTEXTS` edit. **The property that makes a handover cheap to apply is the same property that makes it invisible to the guard** — no wiring change to forget means nothing to notice missing.

So this is neither of the two failure shapes already on record. `#324` was a handover *never posted*, caught by checking the URL. `postguard-e2e#50` was posted, correct, and unapplied, caught only by reading the file — in a repo with no guard at all. This one is in a repo **with** the guard, and the guard's shape is job-level while the handover is step-level.

## The changes, applied verbatim

**`integration.yml`** — a `Prettier (format check)` step running `pnpm --filter @e4a/pg-js lint`. Until now `.husky/pre-commit` was the only thing checking the SDK's formatting, and a hook sees only staged files and loses to `--no-verify`.

**`examples.yml`** — `Every example declares lint`, the sibling of `Every example declares typecheck` ten lines above it. The `Lint` step was fail-open: `pnpm --filter './examples/*' run lint` skips a package declaring no `lint` script and exits **0**, so it has been green while linting one example of three. #270 gave the other two a `lint` script; this is what stops the step going quiet again when a fourth example arrives. The remedy was already written, adjacent, and simply not applied to its neighbour.

## Verification

The guard was run rather than read, in both directions — a check whose failure mode is indistinguishable from its pass is not a check:

| input | result |
|---|---|
| the real tree | `3 example packages, each declaring lint` — green |
| a probe example with `typecheck` but no `lint` | `::error::… declares no "lint" script`, exit 1 |
| `"lint": ""` | rejected — the case that matters, since pnpm runs an empty script as exit 0 |

And `prettier --check .` passes on `packages/pg-js` at this sha, so the new `integration.yml` step lands green rather than red on a backlog — worth checking, because #270 added that `lint` script without ever invoking it in CI.
